### PR TITLE
fix: Add defaultContent to JSONEditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ const editor = new JSONEditor({
 ### properties
 
 - `content: { json: JSON } | { text: string }` Pass the JSON contents to be rendered in the JSONEditor. Contents is an object containing a property `json` and `text`. Only one of the two must be defined. In case of `tree` mode, `json` is used. In case of `code` mode, `text` is used.
+- `defaultContent: { json: JSON } | { text: string }` Pass contents to be set as the content value on first render. This is helpful specifically for React or other scenarios where you want to pass a start value into the editor without controlling content on each change.
 - `mode: 'tree' | 'code'`. Open the editor in `'tree'` mode (default) or `'code'` mode.
 - `mainMenuBar: boolean` Show the main menu bar. Default value is `true`.
 - `navigationBar: boolean` Show the navigation bar with, where you can see the selected path and navigate through your document from there. Default value is `true`.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev": "svelte-kit dev",
     "preview": "svelte-kit preview",
     "build": "npm run package",
+    "build:watch": "npm run package -- --watch",
     "package": "svelte-kit package && rollup --config rollup.config.bundle.js",
     "test": "mocha",
     "check": "svelte-check --tsconfig ./tsconfig.json",

--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -14,8 +14,9 @@
   // TODO: document how to enable debugging in the readme: localStorage.debug="jsoneditor:*", then reload
   const debug = createDebug('jsoneditor:Main')
 
+  export let defaultContent = { text: '' }
   // eslint-disable-next-line no-undef-init
-  export let content = { text: '' }
+  export let content = defaultContent
 
   $: {
     const contentError = validateContentType(content)


### PR DESCRIPTION
This will allow react or other frameworks to initialize the editor with content and still recieve
updated content through onChange, but not continue to control the value as it is changed.

Relates to #23 