### PR TITLE
devDependencies: add rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "mocha": "9.1.3",
     "prettier": "2.4.1",
     "prettier-plugin-svelte": "2.4.0",
+    "rollup": "^2.59.0",
     "rollup-plugin-svelte": "7.1.0",
     "rollup-plugin-terser": "7.0.2",
     "standard-version": "9.3.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mocha": "9.1.3",
     "prettier": "2.4.1",
     "prettier-plugin-svelte": "2.4.0",
-    "rollup": "^2.59.0",
+    "rollup": "2.59.0",
     "rollup-plugin-svelte": "7.1.0",
     "rollup-plugin-terser": "7.0.2",
     "standard-version": "9.3.2",


### PR DESCRIPTION
add rollup to devDependencies

why?
pnpm thinks its smarter than the npm standard
and [pnpm will refuses to install peerDependencies ...](https://github.com/pnpm/pnpm/issues/827)

todo update package lock
