### PR TITLE
Update ContextMenu.scss

### DIFF
--- a/src/lib/components/modes/treemode/JSONNode.scss
+++ b/src/lib/components/modes/treemode/JSONNode.scss
@@ -91,7 +91,7 @@
 
     &.after {
       display: flex;
-      align-items: end;
+      align-items: flex-end;
       line-height: $line-height;
     }
   }

--- a/src/lib/components/modes/treemode/contextmenu/ContextMenu.scss
+++ b/src/lib/components/modes/treemode/contextmenu/ContextMenu.scss
@@ -21,7 +21,7 @@
   .row {
     display: flex;
     flex-direction: row;
-    align-items: start;
+    align-items: flex-start;
     justify-content: stretch;
 
     div.label {


### PR DESCRIPTION
Get rid of warning message when building - start/end has mixed support, flex-start & flex-end has better support