### PR TITLE
improve readOnly option

### DIFF
--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -93,6 +93,7 @@
   const readOnlyCompartment = new Compartment()
   const indentUnitCompartment = new Compartment()
   const tabSizeCompartment = new Compartment()
+  const editableCompartment = new Compartment()
 
   $: isNewDocument = text.length === 0
   $: tooLarge = text && text.length > MAX_DOCUMENT_SIZE_TEXT_MODE
@@ -481,6 +482,7 @@
           top: true
         }),
         readOnlyCompartment.of(EditorState.readOnly.of(readOnly)),
+        editableCompartment.of(EditorView.editable.of(!readOnly)),
         tabSizeCompartment.of(EditorState.tabSize.of(tabSize)),
         indentUnitCompartment.of(createIndentUnit(indentation)),
         EditorView.lineWrapping


### PR DESCRIPTION
I notified that keyboard  is appeared on mobile device even `readOnly` is set `true` when user tap on editor. 

Set `EditorView.editable -> false` disable appeared keyboard on tap or select

<img src="https://user-images.githubusercontent.com/17071211/186904692-89f1ebca-eefe-4ead-a769-f87e1f32136a.png" width="400"  />

