### PR TITLE
New feature added: custom drop down button with custom items possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "ts-node": "10.9.1",
         "tslib": "2.4.0",
         "typescript": "4.8.2",
-        "vite": "3.1.0-beta.1"
+        "vite": "^3.1.0-beta.1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "svelte-jsoneditor",
+  "name": "@mercurio123/svelte-jsoneditor",
   "description": "A web-based tool to view, edit, format, transform, and validate JSON",
   "version": "0.7.1",
   "type": "module",
@@ -9,7 +9,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/josdejong/svelte-jsoneditor.git"
+    "url": "https://github.com/mercurio123/svelte-jsoneditor.git"
   },
   "license": "ISC",
   "scripts": {

--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -36,7 +36,8 @@
     SortModalCallback,
     TransformModalCallback,
     TransformModalOptions,
-    Validator
+    Validator,
+    CustomDropdownButtonItem
   } from '../types'
   import { Mode } from '../types'
   import type { JSONPatchDocument, JSONPath } from 'immutable-json-patch'
@@ -75,6 +76,9 @@
   export let onFocus: OnFocus = noop
   export let onBlur: OnBlur = noop
 
+  //Used to control the visibility of a custuom drop down buttton for the context menu.
+  export let customDropdownButton: Boolean = false
+  export let customDropdownItems: CustomDropdownButtonItem[]
   let instanceId = uniqueId()
 
   let hasFocus = false
@@ -446,6 +450,8 @@
             onRenderMenu={handleRenderMenu}
             {onSortModal}
             {onTransformModal}
+            {customDropdownButton}
+            {customDropdownItems}
           />
         {/if}
       {/key}

--- a/src/lib/components/controls/CustomDropdownButton.svelte
+++ b/src/lib/components/controls/CustomDropdownButton.svelte
@@ -1,0 +1,80 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import Icon from 'svelte-awesome'
+  import { faCaretDown } from '@fortawesome/free-solid-svg-icons'
+  import { onDestroy, onMount } from 'svelte'
+  import { keyComboFromEvent } from '../../utils/keyBindings'
+  import type { CustomDropdownButtonItem } from '../../types'
+
+  export let items: CustomDropdownButtonItem[] = []
+  export let title: string | undefined = undefined
+  export let width = '120px'
+
+  let visible = false
+
+  $: allItemsDisabled = items.every((item) => item.disabled === true)
+
+  function toggleShow() {
+    const wasVisible = visible
+
+    // trigger *after* the handleClick which changes visibility to false
+    setTimeout(() => (visible = !wasVisible))
+  }
+
+  function handleClick() {
+    visible = false
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    const combo = keyComboFromEvent(event)
+    if (combo === 'Escape') {
+      event.preventDefault()
+      visible = false
+    }
+  }
+
+  onMount(() => {
+    document.addEventListener('click', handleClick)
+    document.addEventListener('keydown', handleKeyDown)
+  })
+
+  onDestroy(() => {
+    document.removeEventListener('click', handleClick)
+    document.removeEventListener('keydown', handleKeyDown)
+  })
+</script>
+
+<div class="jse-dropdown-button" {title} on:click={handleClick}>
+  <slot name="defaultItem" />
+
+  <button
+    type="button"
+    class="jse-open-dropdown"
+    data-type="jse-open-dropdown"
+    class:jse-visible={visible}
+    on:click={toggleShow}
+    disabled={allItemsDisabled}
+  >
+    <Icon data={faCaretDown} />
+  </button>
+
+  <div class="jse-dropdown-items" class:jse-visible={visible} style="width: {width};">
+    <ul>
+      {#each items as item}
+        <li>
+          <button
+            type="button"
+            on:click={() => item.onClick(item.structure)}
+            title={item.title}
+            disabled={item.disabled}
+          >
+            {item.text}
+          </button>
+        </li>
+      {/each}
+    </ul>
+  </div>
+</div>
+
+<style src="./DropdownButton.scss"></style>

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -133,13 +133,15 @@
     TreeModeContext,
     ValidationError,
     Validator,
-    ValueNormalization
+    ValueNormalization,
+    CustomDropdownButtonItem
   } from '$lib/types'
   import { isAfterSelection, isInsideSelection, isKeySelection } from '../../../logic/selection'
   import { truncate } from '../../../utils/stringUtils.js'
   import { MAX_CHARACTERS_TEXT_PREVIEW } from '../../../constants.js'
   import memoizeOne from 'memoize-one'
   import { isTextContent } from '$lib'
+  import CustomDropdownButton from '$lib/components/controls/CustomDropdownButton.svelte'
 
   const debug = createDebug('jsoneditor:TreeMode')
 
@@ -181,6 +183,10 @@
   // modalOpen is true when one of the modals is open.
   // This is used to track whether the editor still has focus
   let modalOpen = false
+
+  //Used to control the visibility of a custuom drop down buttton for the context menu.
+  export let customDropdownButton: Boolean
+  export let customDropdownItems: CustomDropdownButtonItem[]
 
   createFocusTracker({
     onMount,
@@ -2000,6 +2006,8 @@
     showTip
   }: AbsolutePopupOptions) {
     const props = {
+      customDropdownButton,
+      customDropdownItems,
       json,
       documentState: documentState,
       showTip,
@@ -2101,7 +2109,6 @@
     if (readOnly) {
       return
     }
-
     openContextMenu({
       anchor: findParentWithNodeName(event.target, 'BUTTON'),
       offsetTop: 0,
@@ -2261,6 +2268,7 @@
       onContextMenu={handleContextMenuFromTreeMenu}
       onCopy={handleCopy}
       {onRenderMenu}
+      {customDropdownButton}
     />
   {/if}
 

--- a/src/lib/components/modes/treemode/contextmenu/ContextMenu.svelte
+++ b/src/lib/components/modes/treemode/contextmenu/ContextMenu.svelte
@@ -20,6 +20,8 @@
   import { onMount } from 'svelte'
   import Icon from 'svelte-awesome'
   import DropdownButton from '../../../controls/DropdownButton.svelte'
+  import CustomDropdownButton from '$lib/components/controls/CustomDropdownButton.svelte'
+  import type { CustomDropdownButtonItem } from 'src/lib/types'
   import { canConvert, singleItemSelected } from '$lib/logic/selection'
   import { keyComboFromEvent } from '$lib/utils/keyBindings'
   import { isObject, isObjectOrArray } from '$lib/utils/typeUtils'
@@ -31,6 +33,9 @@
 
   export let json: JSONData
   export let documentState: DocumentState
+  //Used to control the visibility of a custom drop down button.
+  export let customDropdownButton: Boolean
+  export let customDropdownItems: CustomDropdownButtonItem[]
 
   export let showTip
 
@@ -63,6 +68,7 @@
         firstEnabledButton.focus()
       }
     })
+    addFunction(customDropdownItems)
   })
 
   $: selection = documentState.selection
@@ -221,6 +227,12 @@
       if (nearest) {
         nearest.focus()
       }
+    }
+  }
+
+  function addFunction(value: CustomDropdownButtonItem[]) {
+    for (let i: number = 0; i < value.length; i++) {
+      value[i].onClick = handleInsertOrConvert
     }
   }
 
@@ -414,6 +426,19 @@
     </div>
   </div>
   <div class="jse-separator" />
+  {#if customDropdownButton}
+    <CustomDropdownButton width="12em" items={customDropdownItems}>
+      <button
+        type="button"
+        slot="defaultItem"
+        title="Custom structure"
+        disabled={!canInsertOrConvertValue}
+      >
+        Custom Structure
+      </button>
+    </CustomDropdownButton>
+    <div class="jse-separator" />
+  {/if}
   <div class="jse-row">
     <button
       type="button"

--- a/src/lib/components/modes/treemode/menu/TreeMenu.svelte
+++ b/src/lib/components/modes/treemode/menu/TreeMenu.svelte
@@ -37,6 +37,8 @@
   export let onCopy
 
   export let onRenderMenu: OnRenderMenu = noop
+  //Not used but since a warning is thrown the variable below has been added.
+  export let customDropdownButton: Boolean
 
   function handleToggleSearch() {
     showSearch = !showSearch

--- a/src/lib/logic/operations.ts
+++ b/src/lib/logic/operations.ts
@@ -34,6 +34,7 @@ import {
 } from './selection.js'
 import type { ClipboardValues, DragInsideAction, JSONSelection } from '../types'
 import { int } from '../utils/numberUtils.js'
+import { text } from 'svelte/internal'
 
 /**
  * Create a JSONPatch for an insert operation.
@@ -518,7 +519,7 @@ export function moveInsideParent(
 export function createNewValue(
   json: JSONData,
   selection: JSONSelection,
-  valueType: 'object' | 'array' | 'structure' | 'value'
+  valueType: 'object' | 'array' | 'structure' | 'value' | 'custom structure'
 ) {
   if (valueType === 'object') {
     return {}
@@ -539,8 +540,8 @@ export function createNewValue(
           return Array.isArray(value)
             ? []
             : isObject(value)
-            ? undefined // leave object as is, will recurse into it
-            : ''
+              ? undefined // leave object as is, will recurse into it
+              : ''
         })
       } else {
         // just a primitive value
@@ -548,7 +549,15 @@ export function createNewValue(
       }
     }
   }
-
+  try {
+    const val = valueType.slice(0, 16)
+    const struc = valueType.slice(17)
+    if (val === 'custom structure') {
+      return JSON.parse(struc)
+    }
+  } catch (error) {
+    console.error(error)
+  }
   // type === value,
   // or type === structure but the parent is no array or an array containing
   // primitive values (and no objects having any structure).

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -121,6 +121,14 @@ export interface DropdownButtonItem {
   disabled?: boolean
 }
 
+export interface CustomDropdownButtonItem {
+  text: string
+  onClick: (structure: string) => void
+  structure: string
+  title?: string
+  disabled?: boolean
+}
+
 export interface MenuButtonItem {
   onClick: () => void
   icon?: FontAwesomeIcon


### PR DESCRIPTION
Regarding issue #82: "Implement an onRenderContextMenu to customize the context menu #82" I modified the context menu in such a way that it is possible to show a custom dropdown button. The items of this special button can be customized. If one does not want this functionality, one can just leave the button invisible. The code is backward compatible.