### PR TITLE
Update jsonUtils.ts

### DIFF
--- a/src/lib/utils/jsonUtils.test.ts
+++ b/src/lib/utils/jsonUtils.test.ts
@@ -1,5 +1,5 @@
 import type { JSONParser } from '$lib/types.js'
-import { deepStrictEqual, strictEqual, throws } from 'assert'
+import { deepStrictEqual, strictEqual, throws, equal, deepEqual } from 'assert'
 import { parse, stringify } from 'lossless-json'
 import {
   calculatePosition,
@@ -209,10 +209,29 @@ describe('jsonUtils', () => {
       deepStrictEqual(convertValue('[1,2,3]', 'array', JSON), [1, 2, 3])
     })
 
-    it('should throw when impossible to convert to an array', () => {
-      throws(() => {
-        convertValue('no valid json text', 'array', JSON)
-      }, /SyntaxError/)
+    it('should return a reasonable array when a value cannot be parsed as JSON', () => {
+      const array = ['no valid json text']
+      deepEqual(convertValue('no valid json text', 'array', JSON),array)
+    })
+
+    it('should return an array with a null value when given invalid JSON value "null"', () => {
+      const array = [null]
+      deepEqual(convertValue(null, 'array', JSON),array)
+    })
+
+    it('should return an array with undefined value when given invalid JSON value "undefined"', () => {
+      const array = [undefined]
+      deepEqual(convertValue(undefined, 'array', JSON),array)
+    })
+
+    it('should return an array with number value when given invalid JSON as number', () => {
+      const array = [1]
+      deepEqual(convertValue(1, 'array', JSON),array)
+    })
+
+    it('should return an array with boolean value when given invalid JSON as boolean', () => {
+      const array = [false]
+      deepEqual(convertValue(false, 'array', JSON),array)
     })
 
     it('should convert an array to an object', () => {
@@ -235,10 +254,39 @@ describe('jsonUtils', () => {
       deepStrictEqual(convertValue('["a", "b", "c"]', 'object', JSON), { 2: 'c', 1: 'b', 0: 'a' })
     })
 
-    it('should throw when impossible to convert to an object', () => {
-      throws(() => {
-        convertValue('no valid json text', 'object', JSON)
-      }, /SyntaxError/)
+    it('should return a reasonable object when a value cannot be parsed as JSON, putting the value in a "value" key', () => {
+      const object = {
+        value: 'no valid json text'
+      }
+      deepEqual(convertValue('no valid json text', 'object', JSON),object)
+    })
+
+    it('should return a reasonable object with a null value under "value" when given invalid JSON value "null"', () => {
+      const object = {
+        value: null
+      }
+      deepEqual(convertValue(null, 'object', JSON),object)
+    })
+
+    it('should return a reasonable object with a undefined value under "value" when given invalid JSON value "undefined"', () => {
+      const object = {
+        value: undefined
+      }
+      deepEqual(convertValue(undefined, 'object', JSON),object)
+    })
+
+    it('should return a reasonable object with a number value under "value" when given invalid JSON of number', () => {
+      const object = {
+        value: 1
+      }
+      deepEqual(convertValue(1, 'object', JSON),object)
+    })
+
+    it('should return a reasonable object with a boolean value under "value" when given invalid JSON value of boolean', () => {
+      const object = {
+        value: false
+      }
+      deepEqual(convertValue(false, 'object', JSON),object)
     })
 
     it('should convert an array to a value', () => {

--- a/src/lib/utils/jsonUtils.test.ts
+++ b/src/lib/utils/jsonUtils.test.ts
@@ -1,5 +1,5 @@
 import type { JSONParser } from '$lib/types.js'
-import { deepStrictEqual, strictEqual, throws, equal, deepEqual } from 'assert'
+import { deepStrictEqual, strictEqual, deepEqual } from 'assert'
 import { parse, stringify } from 'lossless-json'
 import {
   calculatePosition,

--- a/src/lib/utils/jsonUtils.test.ts
+++ b/src/lib/utils/jsonUtils.test.ts
@@ -211,27 +211,27 @@ describe('jsonUtils', () => {
 
     it('should return a reasonable array when a value cannot be parsed as JSON', () => {
       const array = ['no valid json text']
-      deepEqual(convertValue('no valid json text', 'array', JSON),array)
+      deepEqual(convertValue('no valid json text', 'array', JSON), array)
     })
 
     it('should return an array with a null value when given invalid JSON value "null"', () => {
       const array = [null]
-      deepEqual(convertValue(null, 'array', JSON),array)
+      deepEqual(convertValue(null, 'array', JSON), array)
     })
 
     it('should return an array with undefined value when given invalid JSON value "undefined"', () => {
       const array = [undefined]
-      deepEqual(convertValue(undefined, 'array', JSON),array)
+      deepEqual(convertValue(undefined, 'array', JSON), array)
     })
 
     it('should return an array with number value when given invalid JSON as number', () => {
       const array = [1]
-      deepEqual(convertValue(1, 'array', JSON),array)
+      deepEqual(convertValue(1, 'array', JSON), array)
     })
 
     it('should return an array with boolean value when given invalid JSON as boolean', () => {
       const array = [false]
-      deepEqual(convertValue(false, 'array', JSON),array)
+      deepEqual(convertValue(false, 'array', JSON), array)
     })
 
     it('should convert an array to an object', () => {
@@ -258,35 +258,35 @@ describe('jsonUtils', () => {
       const object = {
         value: 'no valid json text'
       }
-      deepEqual(convertValue('no valid json text', 'object', JSON),object)
+      deepEqual(convertValue('no valid json text', 'object', JSON), object)
     })
 
     it('should return a reasonable object with a null value under "value" when given invalid JSON value "null"', () => {
       const object = {
         value: null
       }
-      deepEqual(convertValue(null, 'object', JSON),object)
+      deepEqual(convertValue(null, 'object', JSON), object)
     })
 
     it('should return a reasonable object with a undefined value under "value" when given invalid JSON value "undefined"', () => {
       const object = {
         value: undefined
       }
-      deepEqual(convertValue(undefined, 'object', JSON),object)
+      deepEqual(convertValue(undefined, 'object', JSON), object)
     })
 
     it('should return a reasonable object with a number value under "value" when given invalid JSON of number', () => {
       const object = {
         value: 1
       }
-      deepEqual(convertValue(1, 'object', JSON),object)
+      deepEqual(convertValue(1, 'object', JSON), object)
     })
 
     it('should return a reasonable object with a boolean value under "value" when given invalid JSON value of boolean', () => {
       const object = {
         value: false
       }
-      deepEqual(convertValue(false, 'object', JSON),object)
+      deepEqual(convertValue(false, 'object', JSON), object)
     })
 
     it('should convert an array to a value', () => {

--- a/src/lib/utils/jsonUtils.ts
+++ b/src/lib/utils/jsonUtils.ts
@@ -257,6 +257,9 @@ export function convertValue(
         return [value];
       }
     }
+
+    //all other cases, we return the value as the first key of the array, same as the parsing error under the string case
+    return [value]
   }
 
   if (type === 'object') {
@@ -283,10 +286,13 @@ export function convertValue(
       }
       
       catch(e){
-        //we could not parse the string, so we return the string as the first value of the object with key '0'
-        return {0: value};
+        //we could not parse the string, so we return the string as the first value of the object with key 'value'
+        return {value: value};
       }
     }
+
+    //all other cases, we return the value keyed under "value", same as the parsing error under the string case
+    return {value: value};
   }
 
   if (type === 'value') {

--- a/src/lib/utils/jsonUtils.ts
+++ b/src/lib/utils/jsonUtils.ts
@@ -238,16 +238,23 @@ export function convertValue(
     }
 
     if (typeof value === 'string') {
-      const parsedValue = parser.parse(value)
+      try{
+        const parsedValue = parser.parse(value)
 
-      if (Array.isArray(parsedValue)) {
-        return parsedValue
+        if (Array.isArray(parsedValue)) {
+          return parsedValue
+        }
+
+        if (isObject(parsedValue)) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          return objectToArray(parsedValue)
+        }
       }
-
-      if (isObject(parsedValue)) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        return objectToArray(parsedValue)
+      
+      catch(e){
+        //we could not parse the string, so we return the string as the first key of the array
+        return [value];
       }
     }
   }
@@ -263,14 +270,21 @@ export function convertValue(
     }
 
     if (typeof value === 'string') {
-      const parsedValue = parser.parse(value)
+      try{
+        const parsedValue = parser.parse(value)
 
-      if (isObject(parsedValue)) {
-        return parsedValue as JSONObject
+        if (isObject(parsedValue)) {
+          return parsedValue as JSONObject
+        }
+
+        if (Array.isArray(parsedValue)) {
+          return arrayToObject(parsedValue)
+        }
       }
-
-      if (Array.isArray(parsedValue)) {
-        return arrayToObject(parsedValue)
+      
+      catch(e){
+        //we could not parse the string, so we return the string as the first value of the object with key '0'
+        return {0: value};
       }
     }
   }

--- a/src/lib/utils/jsonUtils.ts
+++ b/src/lib/utils/jsonUtils.ts
@@ -238,7 +238,7 @@ export function convertValue(
     }
 
     if (typeof value === 'string') {
-      try{
+      try {
         const parsedValue = parser.parse(value)
 
         if (Array.isArray(parsedValue)) {
@@ -250,11 +250,9 @@ export function convertValue(
           // @ts-ignore
           return objectToArray(parsedValue)
         }
-      }
-      
-      catch(e){
+      } catch (e) {
         //we could not parse the string, so we return the string as the first key of the array
-        return [value];
+        return [value]
       }
     }
 
@@ -273,7 +271,7 @@ export function convertValue(
     }
 
     if (typeof value === 'string') {
-      try{
+      try {
         const parsedValue = parser.parse(value)
 
         if (isObject(parsedValue)) {
@@ -283,16 +281,14 @@ export function convertValue(
         if (Array.isArray(parsedValue)) {
           return arrayToObject(parsedValue)
         }
-      }
-      
-      catch(e){
+      } catch (e) {
         //we could not parse the string, so we return the string as the first value of the object with key 'value'
-        return {value: value};
+        return { value: value }
       }
     }
 
     //all other cases, we return the value keyed under "value", same as the parsing error under the string case
-    return {value: value};
+    return { value: value }
   }
 
   if (type === 'value') {


### PR DESCRIPTION
Proposed fix for Issue : #160 converting a non-JSON string to Object or Array. This brings back functionality that was present in the classic JSONEditor We catch JSON parse errors and return a reasonable Object / Array.  This is an improvement on the classic editor which used to purge the string value.