### PR TITLE
Implement a path editor in the Navigation Bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,9 @@ const editor = new JSONEditor({
   </div>
   ```
 
-- `validationParser: JSON = JSON`. Only applicable when a `validator` is provided. This is the same as `parser`, except that this parser is used to parse the data before sending it to the validator. Configure a custom JSON parser that is used to parse JSON before passing it to the `validator`. By default, the built-in `JSON` parser is used. When passing a custom `validationParser`, make sure the output of the parser is supported by the configured `validator`. So, when the `validationParser` can output `bigint` numbers or other numeric types, the `validator` must also support that. In tree mode, when `parser` is not equal to `validationParser`, the JSON document will be converted before it is passed to the `validator` via `validationParser.parse(parser.stringify(json))`.
+- `validationParser: JSONParser = JSON`. Only applicable when a `validator` is provided. This is the same as `parser`, except that this parser is used to parse the data before sending it to the validator. Configure a custom JSON parser that is used to parse JSON before passing it to the `validator`. By default, the built-in `JSON` parser is used. When passing a custom `validationParser`, make sure the output of the parser is supported by the configured `validator`. So, when the `validationParser` can output `bigint` numbers or other numeric types, the `validator` must also support that. In tree mode, when `parser` is not equal to `validationParser`, the JSON document will be converted before it is passed to the `validator` via `validationParser.parse(parser.stringify(json))`.
+
+- `pathParser: JSONPathParser`. An optional object with a parse and stringify method to parse and stringify a `JSONPath`, which is an array with property names. The `pathParser` is used in the path editor in the navigation bar, which is opened by clicking the edit button on the right side of the navigation bar. The `pathParser.parse` function is allowed to throw an Error when the input is invalid. By default, a JSON Path notation is used, which looks like `$.data[2].nested.property`. Alternatively, it is possible to use for example a JSON Pointer notation like `/data/2/nested/property` or something custom-made. Related helper functions: `parseJSONPath` and `stringifyJSONPath`, `parseJSONPointer` and `compileJSONPointer`.
 
 - `onError(err: Error)`.
   Callback fired when an error occurs. Default implementation is to log an error in the console and show a simple alert message to the user.
@@ -344,7 +346,12 @@ type TextContent = { text: string } | { json: undefined; text: string }
 type JSONContent = { json: JSONData } | { json: JSONData; text: undefined }
 type Content = JSONContent | TextContent
 
-type Path = Array<string | number | symbol>
+type JSONParser = JSON
+
+interface JSONPathParser {
+  parse: (pathStr) => JSONPath
+  stringify: (path: JSONPath) => string
+}
 
 type JSONPatchDocument = JSONPatchOperation[]
 

--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -21,6 +21,7 @@
     JSONEditorPropsOptional,
     JSONParser,
     JSONPatchResult,
+    JSONPathParser,
     MenuItem,
     MenuSeparatorItem,
     OnBlur,
@@ -43,6 +44,7 @@
   import type { JSONPatchDocument, JSONPath } from 'immutable-json-patch'
   import { isMenuSpaceItem } from '../typeguards'
   import { noop } from 'lodash-es'
+  import { parseJSONPath, stringifyJSONPath } from '$lib/utils/pathUtils'
 
   // TODO: document how to enable debugging in the readme: localStorage.debug="jsoneditor:*", then reload
   const debug = createDebug('jsoneditor:Main')
@@ -61,6 +63,10 @@
   export let parser: JSONParser = JSON
   export let validator: Validator | null = null
   export let validationParser: JSONParser = JSON
+  export let pathParser: JSONPathParser = {
+    parse: parseJSONPath,
+    stringify: stringifyJSONPath
+  }
 
   export let queryLanguages: QueryLanguage[] = [javascriptQueryLanguage]
   export let queryLanguageId: string = queryLanguages[0].id
@@ -453,6 +459,7 @@
             {parser}
             {validator}
             {validationParser}
+            {pathParser}
             {onError}
             onChange={handleChange}
             onRequestRepair={handleRequestRepair}

--- a/src/lib/components/controls/ValidationErrorsOverview.svelte
+++ b/src/lib/components/controls/ValidationErrorsOverview.svelte
@@ -8,8 +8,9 @@
   } from '@fortawesome/free-solid-svg-icons'
   import { isEmpty } from 'lodash-es'
   import Icon from 'svelte-awesome'
-  import { stringifyPath } from '../../utils/pathUtils.js'
+  import { stringifyJSONPath } from '../../utils/pathUtils.js'
   import type { ValidationError } from '../../types'
+  import { stripRootObject } from '$lib/utils/pathUtils.js'
 
   export let validationErrors: ValidationError[]
   export let selectError: (error: ValidationError) => void
@@ -42,7 +43,7 @@
                 <Icon data={faExclamationTriangle} />
               </td>
               <td>
-                {stringifyPath(validationError.path)}
+                {stripRootObject(stringifyJSONPath(validationError.path))}
               </td>
               <td>
                 {validationError.message}

--- a/src/lib/components/controls/navigationBar/NavigationBar.scss
+++ b/src/lib/components/controls/navigationBar/NavigationBar.scss
@@ -13,8 +13,30 @@
   border-left: var(--jse-main-border);
   border-right: var(--jse-main-border);
 
-  .jse-navigation-bar-space {
+  .jse-navigation-bar-edit {
+    font-family: var(--jse-font-family-mono);
+    font-size: var(--jse-font-size-mono);
     padding: $padding-half $padding;
-    color: var(--jse-navigation-bar-color);
+    color: var(--jse-panel-color-readonly);
+    border: none;
+    display: flex;
+    cursor: pointer;
+
+    &.flex {
+      flex: 1;
+    }
+
+    &:focus,
+    &:hover,
+    &.editing {
+      background: var(--jse-panel-button-background-highlight);
+      color: var(--jse-panel-button-color-highlight);
+      transition: color 0.2s ease-in, background 0.2s ease-in;
+    }
+
+    .jse-navigation-bar-space {
+      flex: 1;
+      text-align: left;
+    }
   }
 }

--- a/src/lib/components/controls/navigationBar/NavigationBar.scss
+++ b/src/lib/components/controls/navigationBar/NavigationBar.scss
@@ -18,9 +18,12 @@
     font-size: var(--jse-font-size-mono);
     padding: $padding-half $padding;
     color: var(--jse-panel-color-readonly);
+    background: transparent;
     border: none;
     display: flex;
     cursor: pointer;
+    outline: none;
+    align-items: center;
 
     &.flex {
       flex: 1;

--- a/src/lib/components/controls/navigationBar/NavigationBar.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBar.svelte
@@ -11,7 +11,7 @@
   import { caseInsensitiveNaturalCompare } from '../../../logic/sort'
   import type { DocumentState, OnSelect } from '../../../types'
   import Icon from 'svelte-awesome'
-  import { faEdit } from '@fortawesome/free-solid-svg-icons'
+  import { faClose, faEdit } from '@fortawesome/free-solid-svg-icons'
   import NavigationBarPathEditor from '$lib/components/controls/navigationBar/NavigationBarPathEditor.svelte'
 
   const debug = createDebug('jsoneditor:NavigationBar')
@@ -98,7 +98,7 @@
     class="jse-navigation-bar-edit"
     class:flex={!editing}
     class:editing
-    title="Edit the selected path"
+    title={editing ? 'Cancel editing the selected path' : 'Edit the selected path'}
     on:click={toggleEditing}
     bind:this={refEditButton}
   >
@@ -107,7 +107,7 @@
       {!isObjectOrArray(json) && !editing ? 'Navigation bar' : '\u00A0'}
     </span>
 
-    <Icon data={faEdit} />
+    <Icon data={editing ? faClose : faEdit} />
   </button>
 </div>
 

--- a/src/lib/components/controls/navigationBar/NavigationBar.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBar.svelte
@@ -9,7 +9,7 @@
   import { createDebug } from '../../../utils/debug'
   import NavigationBarItem from '../../../components/controls/navigationBar/NavigationBarItem.svelte'
   import { caseInsensitiveNaturalCompare } from '../../../logic/sort'
-  import type { DocumentState, OnSelect } from '../../../types'
+  import type { DocumentState, OnError, OnSelect } from '../../../types'
   import Icon from 'svelte-awesome'
   import { faClose, faEdit } from '@fortawesome/free-solid-svg-icons'
   import NavigationBarPathEditor from '$lib/components/controls/navigationBar/NavigationBarPathEditor.svelte'
@@ -19,6 +19,7 @@
   export let json: JSONValue
   export let documentState: DocumentState
   export let onSelect: OnSelect
+  export let onError: OnError
 
   let refNavigationBar: Element | undefined
   let refEditButton: HTMLButtonElement | undefined
@@ -98,6 +99,7 @@
       {path}
       onClose={handleCloseEditor}
       onChange={handleChangePath}
+      {onError}
       {pathExists}
     />
   {/if}

--- a/src/lib/components/controls/navigationBar/NavigationBar.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBar.svelte
@@ -9,7 +9,7 @@
   import { createDebug } from '../../../utils/debug'
   import NavigationBarItem from '../../../components/controls/navigationBar/NavigationBarItem.svelte'
   import { caseInsensitiveNaturalCompare } from '../../../logic/sort'
-  import type { DocumentState, OnError, OnSelect } from '../../../types'
+  import type { DocumentState, JSONPathParser, OnError, OnSelect } from '../../../types'
   import Icon from 'svelte-awesome'
   import { faClose, faEdit } from '@fortawesome/free-solid-svg-icons'
   import NavigationBarPathEditor from '$lib/components/controls/navigationBar/NavigationBarPathEditor.svelte'
@@ -20,6 +20,7 @@
   export let documentState: DocumentState
   export let onSelect: OnSelect
   export let onError: OnError
+  export let pathParser: JSONPathParser
 
   let refNavigationBar: Element | undefined
   let refEditButton: HTMLButtonElement | undefined
@@ -101,6 +102,7 @@
       onChange={handleChangePath}
       {onError}
       {pathExists}
+      {pathParser}
     />
   {/if}
 

--- a/src/lib/components/controls/navigationBar/NavigationBar.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBar.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import type { JSONValue, JSONPath } from 'immutable-json-patch'
+  import type { JSONPath, JSONValue } from 'immutable-json-patch'
   import { getIn } from 'immutable-json-patch'
   import { range } from 'lodash-es'
   import { isObject, isObjectOrArray } from '../../../utils/typeUtils'
@@ -10,6 +10,9 @@
   import NavigationBarItem from '../../../components/controls/navigationBar/NavigationBarItem.svelte'
   import { caseInsensitiveNaturalCompare } from '../../../logic/sort'
   import type { DocumentState, OnSelect } from '../../../types'
+  import Icon from 'svelte-awesome'
+  import { faEdit } from '@fortawesome/free-solid-svg-icons'
+  import NavigationBarPathEditor from '$lib/components/controls/navigationBar/NavigationBarPathEditor.svelte'
 
   const debug = createDebug('jsoneditor:NavigationBar')
 
@@ -18,6 +21,7 @@
   export let onSelect: OnSelect
 
   let refNavigationBar: Element | undefined
+  let editing = false
 
   $: path = documentState.selection ? documentState.selection.focusPath : []
   $: hasNextItem = isObjectOrArray(getIn(json, path))
@@ -61,19 +65,39 @@
 
     onSelect(createMultiSelection(json, path, path))
   }
+
+  function toggleEditing() {
+    editing = !editing
+  }
 </script>
 
 <div class="jse-navigation-bar" bind:this={refNavigationBar}>
-  {#each path as item, index (index)}
-    <NavigationBarItem {getItems} {path} {index} onSelect={handleSelect} />
-  {/each}
-  {#if hasNextItem}
-    <NavigationBarItem {getItems} {path} index={undefined} onSelect={handleSelect} />
+  {#if !editing}
+    {#each path as item, index (index)}
+      <NavigationBarItem {getItems} {path} {index} onSelect={handleSelect} />
+    {/each}
+    {#if hasNextItem}
+      <NavigationBarItem {getItems} {path} index={undefined} onSelect={handleSelect} />
+    {/if}
+  {:else}
+    <NavigationBarPathEditor {path} />
   {/if}
-  <div class="jse-navigation-bar-space">
-    <!-- ensure the right height (arrows have less height than the text) -->
-    {!isObjectOrArray(json) ? 'Navigation bar' : '\u00A0'}
-  </div>
+
+  <button
+    type="button"
+    class="jse-navigation-bar-edit"
+    class:flex={!editing}
+    class:editing
+    title="Click to edit the selected path"
+    on:click={toggleEditing}
+  >
+    <span class="jse-navigation-bar-space">
+      <!-- ensure the right height (arrows have less height than the text) -->
+      {!isObjectOrArray(json) && !editing ? 'Navigation bar' : '\u00A0'}
+    </span>
+
+    <Icon data={faEdit} />
+  </button>
 </div>
 
 <style src="./NavigationBar.scss"></style>

--- a/src/lib/components/controls/navigationBar/NavigationBar.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBar.svelte
@@ -7,12 +7,12 @@
   import { isObject, isObjectOrArray } from '../../../utils/typeUtils'
   import { createMultiSelection } from '../../../logic/selection'
   import { createDebug } from '../../../utils/debug'
-  import NavigationBarItem from '../../../components/controls/navigationBar/NavigationBarItem.svelte'
   import { caseInsensitiveNaturalCompare } from '../../../logic/sort'
   import type { DocumentState, JSONPathParser, OnError, OnSelect } from '../../../types'
   import Icon from 'svelte-awesome'
   import { faClose, faEdit } from '@fortawesome/free-solid-svg-icons'
-  import NavigationBarPathEditor from '$lib/components/controls/navigationBar/NavigationBarPathEditor.svelte'
+  import NavigationBarItem from './NavigationBarItem.svelte'
+  import NavigationBarPathEditor from './NavigationBarPathEditor.svelte'
 
   const debug = createDebug('jsoneditor:NavigationBar')
 

--- a/src/lib/components/controls/navigationBar/NavigationBar.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBar.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   import type { JSONPath, JSONValue } from 'immutable-json-patch'
-  import { getIn } from 'immutable-json-patch'
+  import { existsIn, getIn } from 'immutable-json-patch'
   import { range } from 'lodash-es'
   import { isObject, isObjectOrArray } from '../../../utils/typeUtils'
   import { createMultiSelection } from '../../../logic/selection'
@@ -61,6 +61,10 @@
     }
   }
 
+  function pathExists(path: JSONPath): boolean {
+    return existsIn(json, path)
+  }
+
   function handleSelect(path: JSONPath) {
     debug('select path', JSON.stringify(path))
 
@@ -90,7 +94,12 @@
       <NavigationBarItem {getItems} {path} index={undefined} onSelect={handleSelect} />
     {/if}
   {:else}
-    <NavigationBarPathEditor {path} onClose={handleCloseEditor} onChange={handleChangePath} />
+    <NavigationBarPathEditor
+      {path}
+      onClose={handleCloseEditor}
+      onChange={handleChangePath}
+      {pathExists}
+    />
   {/if}
 
   <button

--- a/src/lib/components/controls/navigationBar/NavigationBar.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBar.svelte
@@ -21,6 +21,7 @@
   export let onSelect: OnSelect
 
   let refNavigationBar: Element | undefined
+  let refEditButton: HTMLButtonElement | undefined
   let editing = false
 
   $: path = documentState.selection ? documentState.selection.focusPath : []
@@ -69,6 +70,15 @@
   function toggleEditing() {
     editing = !editing
   }
+
+  function handleCloseEditor() {
+    editing = false
+  }
+
+  function handleChangePath(path: JSONPath) {
+    handleCloseEditor()
+    handleSelect(path)
+  }
 </script>
 
 <div class="jse-navigation-bar" bind:this={refNavigationBar}>
@@ -80,7 +90,7 @@
       <NavigationBarItem {getItems} {path} index={undefined} onSelect={handleSelect} />
     {/if}
   {:else}
-    <NavigationBarPathEditor {path} />
+    <NavigationBarPathEditor {path} onClose={handleCloseEditor} onChange={handleChangePath} />
   {/if}
 
   <button
@@ -88,8 +98,9 @@
     class="jse-navigation-bar-edit"
     class:flex={!editing}
     class:editing
-    title="Click to edit the selected path"
+    title="Edit the selected path"
     on:click={toggleEditing}
+    bind:this={refEditButton}
   >
     <span class="jse-navigation-bar-space">
       <!-- ensure the right height (arrows have less height than the text) -->

--- a/src/lib/components/controls/navigationBar/NavigationBarPathEditor.scss
+++ b/src/lib/components/controls/navigationBar/NavigationBarPathEditor.scss
@@ -4,6 +4,7 @@
   flex: 1;
   display: flex;
   border: var(--jse-edit-outline);
+  background: var(--jse-background-color);
 
   input.jse-navigation-bar-text {
     flex: 1;
@@ -26,6 +27,9 @@
   }
 
   button.jse-navigation-bar-copy {
+    &.copied {
+      color: var(--jse-message-success-background);
+    }
   }
 
   button.jse-navigation-bar-validation-error {
@@ -38,5 +42,14 @@
     input.jse-navigation-bar-text {
       color: var(--jse-error-color);
     }
+  }
+
+  .jse-copied-text {
+    background: var(--jse-message-success-background);
+    color: var(--jse-message-success-color);
+    position: relative;
+    margin: 2px;
+    padding: 0 5px;
+    border-radius: $border-radius;
   }
 }

--- a/src/lib/components/controls/navigationBar/NavigationBarPathEditor.scss
+++ b/src/lib/components/controls/navigationBar/NavigationBarPathEditor.scss
@@ -1,0 +1,26 @@
+@import '../../../styles';
+
+.jse-navigation-bar-path-editor {
+  flex: 1;
+  display: flex;
+  border: var(--jse-edit-outline);
+
+  input.jse-navigation-bar-text {
+    flex: 1;
+    font-family: inherit;
+    font-size: inherit;
+    padding: 0 5px 1px;
+    background: var(--jse-background-color);
+    border: none;
+    outline: none;
+  }
+
+  button.jse-navigation-bar-copy {
+    border: none;
+    background: var(--jse-background-color);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 80%;
+    color: inherit;
+  }
+}

--- a/src/lib/components/controls/navigationBar/NavigationBarPathEditor.scss
+++ b/src/lib/components/controls/navigationBar/NavigationBarPathEditor.scss
@@ -11,16 +11,32 @@
     font-size: inherit;
     padding: 0 5px 1px;
     background: var(--jse-background-color);
+    color: var(--jse-text-color);
     border: none;
     outline: none;
   }
 
-  button.jse-navigation-bar-copy {
+  button {
     border: none;
     background: var(--jse-background-color);
     cursor: pointer;
     font-family: inherit;
     font-size: 80%;
     color: inherit;
+  }
+
+  button.jse-navigation-bar-copy {
+  }
+
+  button.jse-navigation-bar-validation-error {
+    color: var(--jse-error-color);
+  }
+
+  &.error {
+    border-color: var(--jse-error-color);
+
+    input.jse-navigation-bar-text {
+      color: var(--jse-error-color);
+    }
   }
 }

--- a/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
@@ -1,36 +1,87 @@
 <script lang="ts">
   import type { JSONPath } from 'immutable-json-patch'
-  import { stringifyJSONPath } from '$lib/utils/pathUtils'
-  import { onMount } from 'svelte'
+  import { parseJSONPath, stringifyJSONPath } from '$lib/utils/pathUtils'
+  import { getContext, onMount } from 'svelte'
   import copyToClipBoard from '$lib/utils/copyToClipboard'
-  import { faCopy } from '@fortawesome/free-solid-svg-icons'
+  import { faCopy, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
   import Icon from 'svelte-awesome'
+  import { keyComboFromEvent } from '$lib/utils/keyBindings'
+  import { tooltip } from '../../controls/tooltip/tooltip.ts'
+
+  const absolutePopupContext = getContext('absolute-popup')
 
   export let path: JSONPath
+  export let onChange: (updatedPath: JSONPath) => void
+  export let onClose: () => void
 
   let inputRef
-  let pathStr: string
-  $: pathStr = stringifyJSONPath(path)
+  let inputPath: string
+  let validationActive = false
+  $: inputPath = stringifyJSONPath(path)
+  $: inputValidationError = validationActive ? validate(inputPath) : undefined
 
   onMount(() => {
     inputRef.focus()
   })
 
+  function validate(path: string): string | undefined {
+    try {
+      parseJSONPath(path)
+      return undefined
+    } catch (err) {
+      return err.toString()
+    }
+  }
+
+  function handleInput(event) {
+    inputPath = event.currentTarget.value
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    const combo = keyComboFromEvent(event)
+
+    if (combo === 'Escape') {
+      onClose()
+    }
+
+    if (combo === 'Enter') {
+      validationActive = true
+      try {
+        const updatedPath = parseJSONPath(inputPath)
+        onChange(updatedPath)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+  }
+
   function handleCopy() {
-    copyToClipBoard(pathStr)
-    // TODO: show feedback to the user that
+    copyToClipBoard(inputPath)
+    // TODO: show feedback to the user that the path has been copied
   }
 </script>
 
-<div class="jse-navigation-bar-path-editor">
+<div class="jse-navigation-bar-path-editor" class:error={inputValidationError}>
   <input
     type="text"
     class="jse-navigation-bar-text"
-    value={pathStr}
-    readonly
+    value={inputPath}
     bind:this={inputRef}
-    on:keydown|stopPropagation
+    on:keydown|stopPropagation={handleKeyDown}
+    on:input={handleInput}
   />
+  {#if inputValidationError}
+    <button
+      type="button"
+      class="jse-navigation-bar-validation-error"
+      use:tooltip={{
+        text: inputValidationError,
+        ...absolutePopupContext
+      }}
+    >
+      <Icon data={faExclamationTriangle} />
+    </button>
+  {/if}
   <button
     type="button"
     class="jse-navigation-bar-copy"

--- a/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import type { JSONPath } from 'immutable-json-patch'
+  import { stringifyJSONPath } from '$lib/utils/pathUtils'
+  import { onMount } from 'svelte'
+  import copyToClipBoard from '$lib/utils/copyToClipboard'
+  import { faCopy } from '@fortawesome/free-solid-svg-icons'
+  import Icon from 'svelte-awesome'
+
+  export let path: JSONPath
+
+  let inputRef
+  let pathStr: string
+  $: pathStr = stringifyJSONPath(path)
+
+  onMount(() => {
+    inputRef.focus()
+  })
+
+  function handleCopy() {
+    copyToClipBoard(pathStr)
+    // TODO: show feedback to the user that
+  }
+</script>
+
+<div class="jse-navigation-bar-path-editor">
+  <input
+    type="text"
+    class="jse-navigation-bar-text"
+    value={pathStr}
+    readonly
+    bind:this={inputRef}
+    on:keydown|stopPropagation
+  />
+  <button
+    type="button"
+    class="jse-navigation-bar-copy"
+    title="Copy selected path to the clipboard"
+    on:click={handleCopy}
+  >
+    <Icon data={faCopy} />
+  </button>
+</div>
+
+<style src="./NavigationBarPathEditor.scss"></style>

--- a/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
   import type { JSONPath } from 'immutable-json-patch'
-  import { parseJSONPath, stringifyJSONPath } from '$lib/utils/pathUtils'
   import { getContext, onDestroy, onMount } from 'svelte'
   import copyToClipBoard from '$lib/utils/copyToClipboard'
   import { faCopy, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
   import Icon from 'svelte-awesome'
   import { keyComboFromEvent } from '$lib/utils/keyBindings'
   import { tooltip } from '../../controls/tooltip/tooltip.ts'
-  import type { OnError } from '$lib/types'
+  import type { JSONPathParser, OnError } from '../../../types.ts'
 
   const absolutePopupContext = getContext('absolute-popup')
 
   export let path: JSONPath
+  export let pathParser: JSONPathParser
   export let onChange: (updatedPath: JSONPath) => void
   export let onClose: () => void
   export let onError: OnError
@@ -20,7 +20,7 @@
   let inputRef
   let inputPath: string
   let validationActive = false
-  $: inputPath = stringifyJSONPath(path)
+  $: inputPath = pathParser.stringify(path)
   $: inputValidationError = validationActive ? parseAndValidate(inputPath).error : undefined
 
   let copiedTimer = undefined
@@ -44,7 +44,7 @@
     error: Error | undefined
   } {
     try {
-      const path = parseJSONPath(pathStr)
+      const path = pathParser.parse(pathStr)
       validatePathExists(path)
       return {
         path,

--- a/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
@@ -13,6 +13,7 @@
   export let path: JSONPath
   export let onChange: (updatedPath: JSONPath) => void
   export let onClose: () => void
+  export let pathExists: (path: JSONPath) => boolean
 
   let inputRef
   let inputPath: string
@@ -26,10 +27,17 @@
 
   function validate(path: string): string | undefined {
     try {
-      parseJSONPath(path)
+      const parsedPath = parseJSONPath(path)
+      validatePathExists(parsedPath)
       return undefined
     } catch (err) {
       return err.toString()
+    }
+  }
+
+  function validatePathExists(path: JSONPath) {
+    if (!pathExists(path)) {
+      throw new Error('Path does not exist')
     }
   }
 
@@ -48,6 +56,7 @@
       validationActive = true
       try {
         const updatedPath = parseJSONPath(inputPath)
+        validatePathExists(updatedPath)
         onChange(updatedPath)
       } catch (err) {
         console.error(err)

--- a/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
@@ -26,12 +26,16 @@
   const copiedDelay = 1000 // ms
 
   onMount(() => {
-    inputRef.focus()
+    focus()
   })
 
   onDestroy(() => {
     clearTimeout(copiedTimer)
   })
+
+  function focus() {
+    inputRef.focus()
+  }
 
   function validate(path: string): string | undefined {
     try {
@@ -76,6 +80,7 @@
     copyToClipBoard(inputPath)
     copied = true
     copiedTimer = setTimeout(() => (copied = false), copiedDelay)
+    focus()
   }
 </script>
 

--- a/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { JSONPath } from 'immutable-json-patch'
   import { parseJSONPath, stringifyJSONPath } from '$lib/utils/pathUtils'
-  import { getContext, onMount } from 'svelte'
+  import { getContext, onDestroy, onMount } from 'svelte'
   import copyToClipBoard from '$lib/utils/copyToClipboard'
   import { faCopy, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
   import Icon from 'svelte-awesome'
@@ -21,8 +21,16 @@
   $: inputPath = stringifyJSONPath(path)
   $: inputValidationError = validationActive ? validate(inputPath) : undefined
 
+  let copiedTimer = undefined
+  let copied = false
+  const copiedDelay = 1000 // ms
+
   onMount(() => {
     inputRef.focus()
+  })
+
+  onDestroy(() => {
+    clearTimeout(copiedTimer)
   })
 
   function validate(path: string): string | undefined {
@@ -66,7 +74,8 @@
 
   function handleCopy() {
     copyToClipBoard(inputPath)
-    // TODO: show feedback to the user that the path has been copied
+    copied = true
+    copiedTimer = setTimeout(() => (copied = false), copiedDelay)
   }
 </script>
 
@@ -91,9 +100,13 @@
       <Icon data={faExclamationTriangle} />
     </button>
   {/if}
+  {#if copied}
+    <div class="jse-copied-text">Copied!</div>
+  {/if}
   <button
     type="button"
     class="jse-navigation-bar-copy"
+    class:copied
     title="Copy selected path to the clipboard"
     on:click={handleCopy}
   >

--- a/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBarPathEditor.svelte
@@ -5,7 +5,7 @@
   import { faCopy, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
   import Icon from 'svelte-awesome'
   import { keyComboFromEvent } from '$lib/utils/keyBindings'
-  import { tooltip } from '../../controls/tooltip/tooltip.ts'
+  import { tooltip } from '../../controls/tooltip/tooltip'
   import type { JSONPathParser, OnError } from '../../../types.ts'
 
   const absolutePopupContext = getContext('absolute-popup')

--- a/src/lib/components/modals/SortModal.svelte
+++ b/src/lib/components/modals/SortModal.svelte
@@ -7,10 +7,10 @@
   import Header from './Header.svelte'
   import { getNestedPaths } from '../../utils/arrayUtils.js'
   import { isObject } from '../../utils/typeUtils.js'
-  import { stringifyPath } from '../../utils/pathUtils.js'
+  import { pathToOption, stringifyJSONPath } from '../../utils/pathUtils.js'
   import { sortArray, sortObjectKeys } from '../../logic/sort.js'
   import { sortModalState } from './sortModalState.js'
-  import type { JSONValue, JSONPath } from 'immutable-json-patch'
+  import type { JSONPath, JSONValue } from 'immutable-json-patch'
   import { compileJSONPointer, getIn } from 'immutable-json-patch'
   import { createDebug } from '../../utils/debug'
   import type { OnSort } from '../../types'
@@ -62,13 +62,6 @@
     }
 
     debug('store state in memory', stateId, sortModalState[stateId])
-  }
-
-  function pathToOption(path: JSONPath): { value: JSONPath; label: string } {
-    return {
-      value: path,
-      label: isEmpty(path) ? '(whole item)' : stringifyPath(path)
-    }
   }
 
   function handleSort() {
@@ -123,7 +116,7 @@
               type="text"
               readonly
               title="Selected path"
-              value={!isEmpty(selectedPath) ? stringifyPath(selectedPath) : '(whole document)'}
+              value={!isEmpty(selectedPath) ? stringifyJSONPath(selectedPath) : '(whole document)'}
             />
           </td>
         </tr>

--- a/src/lib/components/modals/TransformModal.svelte
+++ b/src/lib/components/modals/TransformModal.svelte
@@ -9,7 +9,7 @@
   import { DEBOUNCE_DELAY } from '../../constants.js'
   import type { JSONPath, JSONValue } from 'immutable-json-patch'
   import { compileJSONPointer, getIn } from 'immutable-json-patch'
-  import { stringifyPath } from '../../utils/pathUtils.js'
+  import { stringifyJSONPath } from '../../utils/pathUtils.js'
   import { transformModalState } from './transformModalState.js'
   import TransformWizard from './TransformWizard.svelte'
   import TransformModalHeader from './TransformModalHeader.svelte'
@@ -200,7 +200,7 @@
             type="text"
             readonly
             title="Selected path"
-            value={!isEmpty(selectedPath) ? stringifyPath(selectedPath) : '(whole document)'}
+            value={!isEmpty(selectedPath) ? stringifyJSONPath(selectedPath) : '(whole document)'}
           />
 
           <div class="jse-label">

--- a/src/lib/components/modals/TransformWizard.svelte
+++ b/src/lib/components/modals/TransformWizard.svelte
@@ -3,10 +3,10 @@
 <script lang="ts">
   import Select from 'svelte-select'
   import { getNestedPaths } from '../../utils/arrayUtils.js'
-  import { stringifyPath } from '../../utils/pathUtils.js'
+  import { pathToOption } from '../../utils/pathUtils.js'
   import { createDebug } from '../../utils/debug.js'
-  import { isEmpty, isEqual } from 'lodash-es'
-  import type { JSONValue, JSONPath } from 'immutable-json-patch'
+  import { isEqual } from 'lodash-es'
+  import type { JSONPath, JSONValue } from 'immutable-json-patch'
   import { setIn } from 'immutable-json-patch'
   import type { QueryLanguageOptions } from '../../types'
 
@@ -50,13 +50,6 @@
   $: fieldPath = queryOptions?.filter?.path
     ? fieldOptions.find((option) => isEqual(option.value, queryOptions?.filter?.path))
     : null
-
-  function pathToOption(path) {
-    return {
-      value: path,
-      label: isEmpty(path) ? '(whole item)' : stringifyPath(path)
-    }
-  }
 
   function changeFilterPath(path: JSONPath) {
     if (!isEqual(queryOptions?.filter?.path, path)) {

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -121,6 +121,7 @@
     InsertType,
     JSONParser,
     JSONPatchResult,
+    JSONPathParser,
     JSONPointerMap,
     JSONSelection,
     NestedValidationError,
@@ -176,6 +177,7 @@
   export let parser: JSONParser
   export let validator: Validator | null
   export let validationParser: JSONParser
+  export let pathParser: JSONPathParser
   export let indentation: number | string
   export let onError: OnError
   export let onChange: OnChange
@@ -2294,7 +2296,13 @@
   {/if}
 
   {#if navigationBar}
-    <NavigationBar {json} {documentState} onSelect={handleNavigationBarSelect} {onError} />
+    <NavigationBar
+      {json}
+      {documentState}
+      onSelect={handleNavigationBarSelect}
+      {onError}
+      {pathParser}
+    />
   {/if}
 
   {#if !isSSR}

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -2294,7 +2294,7 @@
   {/if}
 
   {#if navigationBar}
-    <NavigationBar {json} {documentState} onSelect={handleNavigationBarSelect} />
+    <NavigationBar {json} {documentState} onSelect={handleNavigationBarSelect} {onError} />
   {/if}
 
   {#if !isSSR}

--- a/src/lib/components/modes/treemode/ValidationErrorIcon.svelte
+++ b/src/lib/components/modes/treemode/ValidationErrorIcon.svelte
@@ -2,7 +2,7 @@
   import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
   import Icon from 'svelte-awesome'
   import { getContext } from 'svelte'
-  import { tooltip } from '../../controls/tooltip/tooltip.ts'
+  import { tooltip } from '../../controls/tooltip/tooltip'
   import type { ValidationError } from '../../../types'
 
   const absolutePopupContext = getContext('absolute-popup')

--- a/src/lib/components/modes/treemode/ValidationErrorIcon.svelte
+++ b/src/lib/components/modes/treemode/ValidationErrorIcon.svelte
@@ -2,7 +2,7 @@
   import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
   import Icon from 'svelte-awesome'
   import { getContext } from 'svelte'
-  import { tooltip } from '../../controls/tooltip/tooltip'
+  import { tooltip } from '../../controls/tooltip/tooltip.ts'
   import type { ValidationError } from '../../../types'
 
   const absolutePopupContext = getContext('absolute-popup')

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -34,6 +34,7 @@ export {
   isLargeContent,
   estimateSerializedSize
 } from './utils/jsonUtils.js'
+export { parseJSONPath, stringifyJSONPath } from './utils/pathUtils.js'
 export {
   isValueSelection,
   isKeySelection,

--- a/src/lib/plugins/query/lodashQueryLanguage.test.ts
+++ b/src/lib/plugins/query/lodashQueryLanguage.test.ts
@@ -271,6 +271,38 @@ describe('lodashQueryLanguage', () => {
       assert.deepStrictEqual(users, originalUsers) // must not touch the original users
     })
 
+    it('should correctly escape and quote orderBy', () => {
+      const item42 = {
+        nested: {
+          'complex "field" \'name\'': 42
+        }
+      }
+      const item0 = {
+        nested: {
+          'complex "field" \'name\'': 0
+        }
+      }
+      const json = [item42, item0]
+      const query = createQuery(json, {
+        sort: {
+          path: ['nested', 'complex "field" \'name\''],
+          direction: 'asc'
+        }
+      })
+
+      const result = executeQuery(json, query)
+
+      assert.deepStrictEqual(
+        query,
+        'function query (data) {\n' +
+          '  data = _.orderBy(data, [["nested","complex \\"field\\" \'name\'"]], [\'asc\'])\n' +
+          '  return data\n' +
+          '}'
+      )
+
+      assert.deepStrictEqual(result, [item0, item42])
+    })
+
     it('should allow defining multiple functions', () => {
       const query =
         'function square(x) {\n' +

--- a/src/lib/plugins/query/lodashQueryLanguage.ts
+++ b/src/lib/plugins/query/lodashQueryLanguage.ts
@@ -1,9 +1,9 @@
 import * as _ from 'lodash-es'
 import { last } from 'lodash-es'
-import { createPropertySelector, stringifyPath } from '../../utils/pathUtils.js'
+import { createLodashPropertySelector, createPropertySelector } from '../../utils/pathUtils.js'
 import { parseString } from '../../utils/stringUtils.js'
 import type { QueryLanguage, QueryLanguageOptions } from '../../types'
-import type { JSONPath, JSONValue } from 'immutable-json-patch'
+import type { JSONValue } from 'immutable-json-patch'
 import { isInteger } from '../../utils/typeUtils.js'
 
 const description = `
@@ -48,7 +48,7 @@ function createQuery(json: JSONValue, queryOptions: QueryLanguageOptions): strin
 
   if (sort && sort.path && sort.direction) {
     queryParts.push(
-      `  data = _.orderBy(data, ['${createLodashPropertySelector(sort.path)}'], ['${
+      `  data = _.orderBy(data, [${createLodashPropertySelector(sort.path)}], ['${
         sort.direction
       }'])\n`
     )
@@ -96,11 +96,4 @@ function executeQuery(json: JSONValue, query: string): JSONValue {
 
   const output = queryFn(json)
   return output !== undefined ? output : null
-}
-
-/**
- * Create a Lodash string containing a path (without leading dot), like "users[2].name"
- */
-function createLodashPropertySelector(path: JSONPath): string {
-  return stringifyPath(path).replace(/^\./, '') // remove any leading dot
 }

--- a/src/lib/plugins/value/components/TimestampTag.svelte
+++ b/src/lib/plugins/value/components/TimestampTag.svelte
@@ -4,7 +4,7 @@
   import Icon from 'svelte-awesome'
   import { faClock } from '@fortawesome/free-regular-svg-icons'
   import { getContext } from 'svelte'
-  import { tooltip } from '$lib/components/controls/tooltip/tooltip.ts'
+  import { tooltip } from '$lib/components/controls/tooltip/tooltip'
 
   const absolutePopupContext = getContext('absolute-popup')
 

--- a/src/lib/plugins/value/components/TimestampTag.svelte
+++ b/src/lib/plugins/value/components/TimestampTag.svelte
@@ -4,7 +4,7 @@
   import Icon from 'svelte-awesome'
   import { faClock } from '@fortawesome/free-regular-svg-icons'
   import { getContext } from 'svelte'
-  import { tooltip } from '../../../components/controls/tooltip/tooltip.js'
+  import { tooltip } from '$lib/components/controls/tooltip/tooltip.ts'
 
   const absolutePopupContext = getContext('absolute-popup')
 

--- a/src/lib/themes/jse-theme-default.css
+++ b/src/lib/themes/jse-theme-default.css
@@ -46,7 +46,6 @@
   --jse-panel-button-background-highlight: #e0e0e0;
 
   /* navigation-bar */
-  --jse-navigation-bar-color: #656565;
   --jse-navigation-bar-background: var(--jse-background-color);
   --jse-navigation-bar-background-highlight: #e5e5e5;
   --jse-navigation-bar-dropdown-color: #656565;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,11 @@ export type Content = JSONContent | TextContent
 
 export type JSONParser = JSON
 
+export interface JSONPathParser {
+  parse: (pathStr) => JSONPath
+  stringify: (path: JSONPath) => string
+}
+
 export interface VisibleSection {
   start: number
   end: number

--- a/src/lib/utils/pathUtils.test.ts
+++ b/src/lib/utils/pathUtils.test.ts
@@ -1,8 +1,9 @@
-import { deepStrictEqual, notStrictEqual, strictEqual } from 'assert'
+import { deepStrictEqual, notStrictEqual, strictEqual, throws } from 'assert'
 import {
   createLodashPropertySelector,
   createMemoizePath,
   createPropertySelector,
+  parseJSONPath,
   pathToOption,
   stringifyJSONPath,
   stripRootObject
@@ -21,6 +22,33 @@ describe('pathUtils', () => {
     strictEqual(stringifyJSONPath(['foo', 'prop-with-hyphens']), "$.foo['prop-with-hyphens']")
     strictEqual(stringifyJSONPath(['foo', 'prop with spaces']), "$.foo['prop with spaces']")
     strictEqual(stringifyJSONPath(['foo', 'prop with \'".[']), "$.foo['prop with '\".[']")
+  })
+
+  it('parseJSONPath', () => {
+    deepStrictEqual(parseJSONPath('$'), [])
+    deepStrictEqual(parseJSONPath("$['']"), [''])
+    deepStrictEqual(parseJSONPath('$.foo'), ['foo'])
+    deepStrictEqual(parseJSONPath('$.foo.bar'), ['foo', 'bar'])
+    deepStrictEqual(parseJSONPath('$.foo[2]'), ['foo', '2'])
+    deepStrictEqual(parseJSONPath('$.foo[2].bar'), ['foo', '2', 'bar'])
+    deepStrictEqual(parseJSONPath('$.foo[2].bar_baz'), ['foo', '2', 'bar_baz'])
+    deepStrictEqual(parseJSONPath('$[2]'), ['2'])
+    deepStrictEqual(parseJSONPath("$.foo['prop-with-hyphens']"), ['foo', 'prop-with-hyphens'])
+    deepStrictEqual(parseJSONPath("$.foo['prop with spaces']"), ['foo', 'prop with spaces'])
+    deepStrictEqual(parseJSONPath("$.foo['prop with '\".[']"), ['foo', 'prop with \'".['])
+
+    // with missing root document or initial dot or enclosing whitespace
+    deepStrictEqual(parseJSONPath('.foo.bar'), ['foo', 'bar'])
+    deepStrictEqual(parseJSONPath('foo.bar'), ['foo', 'bar'])
+    deepStrictEqual(parseJSONPath('[2]'), ['2'])
+    deepStrictEqual(parseJSONPath(' $[2]  '), ['2'])
+
+    throws(() => {
+      parseJSONPath('["hello"]')
+    }, new SyntaxError('Cannot parse path: unexpected part "["hello"]" at position 0'))
+    throws(() => {
+      parseJSONPath('.foo.bar baz')
+    }, new SyntaxError('Cannot parse path: unexpected part " baz" at position 8'))
   })
 
   it('createLodashPropertySelector', () => {

--- a/src/lib/utils/pathUtils.test.ts
+++ b/src/lib/utils/pathUtils.test.ts
@@ -1,19 +1,59 @@
-import { notStrictEqual, strictEqual } from 'assert'
-import { createMemoizePath, createPropertySelector, stringifyPath } from './pathUtils.js'
+import { deepStrictEqual, notStrictEqual, strictEqual } from 'assert'
+import {
+  createLodashPropertySelector,
+  createMemoizePath,
+  createPropertySelector,
+  pathToOption,
+  stringifyJSONPath,
+  stripRootObject
+} from './pathUtils.js'
 
 describe('pathUtils', () => {
-  it('stringifyPath', () => {
-    strictEqual(stringifyPath([]), '')
-    strictEqual(stringifyPath(['']), '[""]')
-    strictEqual(stringifyPath(['foo']), '.foo')
-    strictEqual(stringifyPath(['foo', 'bar']), '.foo.bar')
-    strictEqual(stringifyPath(['foo', '2']), '.foo[2]')
-    strictEqual(stringifyPath(['foo', '2', 'bar']), '.foo[2].bar')
-    strictEqual(stringifyPath(['foo', '2', 'bar_baz']), '.foo[2].bar_baz')
-    strictEqual(stringifyPath(['2']), '[2]')
-    strictEqual(stringifyPath(['foo', 'prop-with-hyphens']), '.foo["prop-with-hyphens"]')
-    strictEqual(stringifyPath(['foo', 'prop with spaces']), '.foo["prop with spaces"]')
-    strictEqual(stringifyPath(['foo', 'prop with ".[']), '.foo["prop with \\".["]')
+  it('stringifyJSONPath', () => {
+    strictEqual(stringifyJSONPath([]), '$')
+    strictEqual(stringifyJSONPath(['']), "$['']")
+    strictEqual(stringifyJSONPath(['foo']), '$.foo')
+    strictEqual(stringifyJSONPath(['foo', 'bar']), '$.foo.bar')
+    strictEqual(stringifyJSONPath(['foo', '2']), '$.foo[2]')
+    strictEqual(stringifyJSONPath(['foo', '2', 'bar']), '$.foo[2].bar')
+    strictEqual(stringifyJSONPath(['foo', '2', 'bar_baz']), '$.foo[2].bar_baz')
+    strictEqual(stringifyJSONPath(['2']), '$[2]')
+    strictEqual(stringifyJSONPath(['foo', 'prop-with-hyphens']), "$.foo['prop-with-hyphens']")
+    strictEqual(stringifyJSONPath(['foo', 'prop with spaces']), "$.foo['prop with spaces']")
+    strictEqual(stringifyJSONPath(['foo', 'prop with \'".[']), "$.foo['prop with '\".[']")
+  })
+
+  it('createLodashPropertySelector', () => {
+    strictEqual(createLodashPropertySelector([]), "''")
+    strictEqual(createLodashPropertySelector(['']), '[""]')
+    strictEqual(createLodashPropertySelector(['foo']), "'foo'")
+    strictEqual(createLodashPropertySelector(['foo', 'bar']), "'foo.bar'")
+    strictEqual(createLodashPropertySelector(['foo', '2']), "'foo[2]'")
+    strictEqual(createLodashPropertySelector(['foo', '2', 'bar']), "'foo[2].bar'")
+    strictEqual(createLodashPropertySelector(['foo', '2', 'bar baz']), '["foo","2","bar baz"]')
+    strictEqual(createLodashPropertySelector(['2']), "'[2]'")
+    strictEqual(
+      createLodashPropertySelector(['foo', 'prop-with-hyphens']),
+      '["foo","prop-with-hyphens"]'
+    )
+    strictEqual(
+      createLodashPropertySelector(['foo', 'prop with spaces']),
+      '["foo","prop with spaces"]'
+    )
+    strictEqual(createLodashPropertySelector(['foo', 'prop with ".[']), '["foo","prop with \\".["]')
+  })
+
+  it('stripRootObject', () => {
+    strictEqual(stripRootObject('$.foo.bar'), 'foo.bar')
+    strictEqual(stripRootObject("$['foo'].bar"), "['foo'].bar")
+  })
+
+  it('pathToOption', () => {
+    deepStrictEqual(pathToOption([]), { value: [], label: '(whole item)' })
+    deepStrictEqual(pathToOption(['users', '2', 'first name']), {
+      value: ['users', '2', 'first name'],
+      label: "users[2]['first name']"
+    })
   })
 
   it('createPropertySelector', () => {

--- a/src/lib/utils/pathUtils.ts
+++ b/src/lib/utils/pathUtils.ts
@@ -1,30 +1,73 @@
-import { memoize } from 'lodash-es'
+import { isEmpty, memoize } from 'lodash-es'
 import type { JSONPath } from 'immutable-json-patch'
 
 /**
  * Stringify a path like:
  *
- *     ["data", 2, "nested", "property"]
+ *     ["data", "2", "nested property", "name"]
  *
- * into a string:
+ * into a JSON path string like:
  *
- *     ".data[2].nested.property"
+ *     "$.data[2]['nested property'].name"
  */
-export function stringifyPath(path: JSONPath): string {
-  return path.map(stringifyPathProp).join('')
+export function stringifyJSONPath(path: JSONPath): string {
+  return '$' + path.map(stringifyJSONPathProp).join('')
 }
 
 /**
- * Stringify a single property of a path. See also stringifyPath
+ * Stringify a single property of a JSON path. See also stringifyJSONPath
  */
-export function stringifyPathProp(prop: string): string {
+export function stringifyJSONPathProp(prop: string): string {
   if (integerNumberRegex.test(prop)) {
     return '[' + prop + ']'
   } else if (javaScriptPropertyRegex.test(prop)) {
     return '.' + prop
   } else {
-    return '[' + JSON.stringify(prop) + ']'
+    const propStr = JSON.stringify(prop)
+    // remove enclosing double quotes, and unescape escaped double qoutes \"
+    const jsonPathStr = propStr.substring(1, propStr.length - 1).replace(/\\"/g, '"')
+    return "['" + jsonPathStr + "']"
   }
+}
+
+/**
+ * Strip the leading '$' and '.' from a JSONPath, for example:
+ *
+ *   "$.data[2].nested.property"
+ *
+ * will be changed into:
+ *
+ *   "data[2].nested.property"
+ */
+export function stripRootObject(path: string): string {
+  return path
+    .replace(/^\$/, '') // remove any leading $ character
+    .replace(/^\./, '') // remove any leading dot
+}
+
+/**
+ * Convert a JSONPath into an option for use in a select box
+ */
+export function pathToOption(path: JSONPath): { value: JSONPath; label: string } {
+  return {
+    value: path,
+    label: isEmpty(path) ? '(whole item)' : stripRootObject(stringifyJSONPath(path))
+  }
+}
+
+/**
+ * Stringify a JSON path into a lodash path like:
+ *
+ *     "data[2].nested.name"
+ *
+ * or
+ *
+ *     ["data", 2, "nested property", "name"]
+ */
+export function createLodashPropertySelector(path: JSONPath): string {
+  return path.every((prop) => integerNumberRegex.test(prop) || javaScriptPropertyRegex.test(prop))
+    ? "'" + path.map(stringifyJSONPathProp).join('').replace(/^\./, '') + "'"
+    : JSON.stringify(path)
 }
 
 /**
@@ -68,5 +111,5 @@ const integerNumberRegex = /^\d+$/
  * the memoized instance of the path when the stringified version is the same.
  */
 export function createMemoizePath(): (path: JSONPath) => JSONPath {
-  return memoize((path) => path, stringifyPath)
+  return memoize((path) => path, stringifyJSONPath)
 }

--- a/src/lib/utils/typeUtils.test.ts
+++ b/src/lib/utils/typeUtils.test.ts
@@ -5,8 +5,12 @@ import {
   isObjectOrArray,
   isStringContainingPrimitiveValue,
   isTimestamp,
-  stringConvert
+  stringConvert,
+  valueType
 } from './typeUtils.js'
+import { LosslessNumber, parse, stringify } from 'lossless-json'
+
+const LosslessJSONParser = { parse, stringify }
 
 describe('typeUtils', () => {
   class TestClass {
@@ -79,6 +83,19 @@ describe('typeUtils', () => {
     strictEqual(stringConvert('2.4 ', JSON), 2.4)
     strictEqual(stringConvert('123ab', JSON), '123ab')
     strictEqual(stringConvert('  ', JSON), '  ')
+  })
+
+  it('valueType', () => {
+    strictEqual(valueType(2, JSON), 'number')
+    strictEqual(valueType('some text', JSON), 'string')
+    strictEqual(valueType(true, JSON), 'boolean')
+    strictEqual(valueType(false, JSON), 'boolean')
+    strictEqual(valueType(null, JSON), 'null')
+    strictEqual(valueType([], JSON), 'array')
+    strictEqual(valueType({}, JSON), 'object')
+    strictEqual(valueType(123n, JSON), 'number')
+    strictEqual(valueType(new Date(), JSON), 'unknown')
+    strictEqual(valueType(new LosslessNumber('123'), LosslessJSONParser as JSON), 'number')
   })
 
   it('isStringContainingPrimitiveValue', () => {

--- a/src/lib/utils/typeUtils.ts
+++ b/src/lib/utils/typeUtils.ts
@@ -93,16 +93,21 @@ export function isColor(value: unknown): boolean {
 /**
  * Get the type of the value
  */
-// TODO: unit test valueType()
 export function valueType(value: unknown, parser: JSONParser): string {
   // primitive types
   if (
     typeof value === 'number' ||
     typeof value === 'string' ||
     typeof value === 'boolean' ||
-    value === null
+    typeof value === 'undefined'
   ) {
     return typeof value
+  }
+  if (typeof value === 'bigint') {
+    return 'number' // we return number here, not bigint: all numeric types should return the same name
+  }
+  if (value === null) {
+    return 'null'
   }
 
   if (Array.isArray(value)) {
@@ -115,10 +120,7 @@ export function valueType(value: unknown, parser: JSONParser): string {
 
   // unknown type. Try out what stringfying results in
   const valueStr = parser.stringify(value)
-  if (valueStr[0] === '"') {
-    return 'string'
-  }
-  if (isDigit(valueStr[0])) {
+  if (valueStr && isDigit(valueStr[0])) {
     return 'number'
   }
   if (valueStr === 'true' || valueStr === 'false') {

--- a/src/routes/development/+page.svelte
+++ b/src/routes/development/+page.svelte
@@ -14,6 +14,8 @@
   import { tick } from 'svelte'
   import { parse, stringify } from 'lossless-json'
   import { truncate } from '$lib/utils/stringUtils.js'
+  import { parseJSONPath, stringifyJSONPath } from '$lib/utils/pathUtils'
+  import { compileJSONPointer, parseJSONPointer } from 'immutable-json-patch'
 
   // const LosslessJSON: JSONParser = { ... } // FIXME: make the types work
   const LosslessJSON = {
@@ -125,6 +127,25 @@
     }
   ]
 
+  const pathParsers = [
+    {
+      id: 'JSONPath',
+      value: {
+        parse: parseJSONPath,
+        stringify: stringifyJSONPath
+      },
+      label: 'JSONPath'
+    },
+    {
+      id: 'JSONPointer',
+      value: {
+        parse: parseJSONPointer,
+        stringify: compileJSONPointer
+      },
+      label: 'JSONPointer'
+    }
+  ]
+
   const validator = createAjvValidator(schema)
 
   let refTreeEditor
@@ -169,6 +190,10 @@
     indentations[0].value
   )
   const selectedParserId = useLocalStorage('svelte-jsoneditor-demo-parser', parsers[0].id)
+  const selectedPathParserId = useLocalStorage(
+    'svelte-jsoneditor-demo-path-parser',
+    pathParsers[0].id
+  )
   const tabSize = useLocalStorage('svelte-jsoneditor-demo-tabSize', indentations[0].value)
   let leftEditorMode = 'tree'
 
@@ -178,6 +203,7 @@
   let queryLanguageId = javascriptQueryLanguage.id // TODO: store in local storage
 
   $: selectedParser = parsers.find((parser) => parser.id === $selectedParserId).value
+  $: selectedPathParser = pathParsers.find((parser) => parser.id === $selectedPathParserId).value
 
   // only editable/readonly div, no color picker, boolean toggle, timestamp
   function customRenderValue({
@@ -338,9 +364,16 @@
   </p>
 
   <p>
-    JSON Parser <select bind:value={$selectedParserId}>
+    JSON Parser: <select bind:value={$selectedParserId}>
       {#each parsers as parser}
         <option value={parser.id}>{parser.label}</option>
+      {/each}
+    </select>
+
+    Path Parser:
+    <select bind:value={$selectedPathParserId}>
+      {#each pathParsers as pathParser}
+        <option value={pathParser.id}>{pathParser.label}</option>
       {/each}
     </select>
   </p>
@@ -516,6 +549,7 @@
             indentation={$selectedIndentation}
             tabSize={$tabSize}
             parser={selectedParser}
+            pathParser={selectedPathParser}
             validator={$validate ? validator : undefined}
             {queryLanguages}
             bind:queryLanguageId
@@ -562,6 +596,7 @@
             indentation={$selectedIndentation}
             tabSize={$tabSize}
             parser={selectedParser}
+            pathParser={selectedPathParser}
             validator={$validate ? validator : undefined}
             {queryLanguages}
             {queryLanguageId}

--- a/src/routes/development/+page.svelte
+++ b/src/routes/development/+page.svelte
@@ -406,7 +406,10 @@
               id: index,
               name: 'Item ' + index,
               random,
-              long: 9223372000000000000n + BigInt(random)
+              long: 9223372000000000000n + BigInt(random),
+              'nested random': {
+                value: random
+              }
             }
           })
         }


### PR DESCRIPTION
Fixes #13 

- Implements a path editor where you can see and modify the path, copy, paste, and just type what you want.
- A special copy button on the right side to conveniently copy the path to clipboard
- Throws and error when the path is invalid or does not not exist in the document
- Customizable format: defaults to JSON Path, but you can configure to use for example JSON Pointer instead using the new `pathParser` option.
- Export two new util functions: `parseJSONPath` and `stringifyJSONPath`


![afbeelding](https://user-images.githubusercontent.com/568626/195559196-a7910d9d-05e4-4e2c-b38e-b24a2dc2ad5c.png)

