### PR TITLE
feat: auto convert non-string content value to JSON string under text mode

### DIFF
--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -95,7 +95,7 @@
   let open // svelte-simple-modal context open(...)
 
   $: {
-    const contentError = validateContentType(content)
+    const contentError = validateContentType(content, parser, indentation)
     if (contentError) {
       console.error('Error: ' + contentError)
     }
@@ -121,7 +121,7 @@
   export function set(newContent: Content) {
     debug('set')
 
-    const contentError = validateContentType(newContent)
+    const contentError = validateContentType(newContent, parser, indentation)
     if (contentError) {
       throw new Error(contentError)
     }
@@ -135,7 +135,7 @@
   export function update(updatedContent: Content) {
     debug('update')
 
-    const contentError = validateContentType(updatedContent)
+    const contentError = validateContentType(updatedContent, parser, indentation)
     if (contentError) {
       throw new Error(contentError)
     }

--- a/src/lib/utils/jsonUtils.test.ts
+++ b/src/lib/utils/jsonUtils.test.ts
@@ -97,26 +97,28 @@ describe('jsonUtils', () => {
   })
 
   it('should validate content type', () => {
-    deepStrictEqual(validateContentType({ json: [1, 2, 3] }), null)
-    deepStrictEqual(validateContentType({ text: '[1,2,3]' }), null)
+    deepStrictEqual(validateContentType({ json: [1, 2, 3] }, JSON, 2), null)
+    deepStrictEqual(validateContentType({ text: '[1,2,3]' }, JSON, 2), null)
 
+    const jsonTextContent = { text: [1, 2, 3] }, jsonTextContentCopy = { ...jsonTextContent }
+    validateContentType(jsonTextContent, JSON, 2)
     deepStrictEqual(
-      validateContentType({ text: [1, 2, 3] }),
-      'Content "text" property must be string'
+      jsonTextContent.text,
+      JSON.stringify(jsonTextContentCopy.text, null, 2)
     )
 
     deepStrictEqual(
-      validateContentType({ json: [1, 2, 3], text: '[1,2,3]' }),
+      validateContentType({ json: [1, 2, 3], text: '[1,2,3]' }, JSON, 2),
       'Content must contain either a property "json" or a property "text" but not both'
     )
 
     deepStrictEqual(
-      validateContentType({}),
+      validateContentType({}, JSON, 2),
       'Content must contain either a property "json" or a property "text"'
     )
 
-    deepStrictEqual(validateContentType([]), 'Content must be an object')
-    deepStrictEqual(validateContentType(2), 'Content must be an object')
+    deepStrictEqual(validateContentType([], JSON, 2), 'Content must be an object')
+    deepStrictEqual(validateContentType(2, JSON, 2), 'Content must be an object')
   })
 
   describe('estimateSerializedSize', () => {

--- a/src/lib/utils/jsonUtils.ts
+++ b/src/lib/utils/jsonUtils.ts
@@ -292,7 +292,11 @@ export function convertValue(
  * Returns a string with validation error message when there is an issue,
  * or null otherwise
  */
-export function validateContentType(content: unknown): string | null {
+export function validateContentType(
+  content: unknown,
+  parser: JSONParser,
+  indentation: number | string | null,
+): string | null {
   if (!isObject(content)) {
     return 'Content must be an object'
   }
@@ -307,7 +311,9 @@ export function validateContentType(content: unknown): string | null {
     if (content.text === undefined) {
       return 'Content must contain either a property "json" or a property "text"'
     } else if (typeof content.text !== 'string') {
-      return 'Content "text" property must be string'
+      // return 'Content "text" property must be string'
+      content.text = parser.stringify(content.text, null, indentation)
+      return null
     } else {
       return null
     }


### PR DESCRIPTION
Hello,

I received these issues https://github.com/cloydlau/json-editor-vue/issues/11 & https://github.com/cloydlau/json-editor-vue/issues/16 recently. Which all caused by using JSON value under text mode.

I'm wondering would it be a little bit weird if a JSON editor don't take JSON value and throw an Error?

My understanding is mode means **writing mode** and might have little to do with value type.

So I did a little change using the new `parser` option to stringify non-string content value under text mode rather than throwing an error. (`lint` & `test` passing)

It can be quite common to use JSON value under text mode. In which case users will have to stringify the content value themselves and therefore the content value will be stringified anyway.