### PR TITLE
fix: incorrect cursor style for Color Picker & Boolean Toggle

### DIFF
--- a/src/lib/plugins/value/components/BooleanToggle.scss
+++ b/src/lib/plugins/value/components/BooleanToggle.scss
@@ -7,3 +7,7 @@
   padding-top: 1px;
   height: var(--jse-line-height);
 }
+
+:global(.jse-json-node:not(.jse-readonly)) .jse-boolean-toggle > :global(svg) {
+  cursor: pointer;
+}

--- a/src/lib/plugins/value/components/BooleanToggle.scss
+++ b/src/lib/plugins/value/components/BooleanToggle.scss
@@ -8,6 +8,6 @@
   height: var(--jse-line-height);
 }
 
-.jse-boolean-toggle:not(.jse-readonly) > :global(svg) {
+.jse-boolean-toggle:not(.jse-readonly) {
   cursor: pointer;
 }

--- a/src/lib/plugins/value/components/BooleanToggle.scss
+++ b/src/lib/plugins/value/components/BooleanToggle.scss
@@ -8,6 +8,6 @@
   height: var(--jse-line-height);
 }
 
-:global(.jse-json-node:not(.jse-readonly)) .jse-boolean-toggle > :global(svg) {
+.jse-boolean-toggle:not(.jse-readonly) > :global(svg) {
   cursor: pointer;
 }

--- a/src/lib/plugins/value/components/BooleanToggle.svelte
+++ b/src/lib/plugins/value/components/BooleanToggle.svelte
@@ -34,6 +34,7 @@
 
 <div
   class="jse-boolean-toggle"
+  class:jse-readonly={readOnly}
   on:mousedown={toggleBooleanValue}
   title={!readOnly ? 'Click to toggle this boolean value' : `Boolean value ${value}`}
 >

--- a/src/lib/plugins/value/components/ColorPicker.scss
+++ b/src/lib/plugins/value/components/ColorPicker.scss
@@ -16,6 +16,6 @@
   outline: none;
 }
 
-:global(.jse-json-node:not(.jse-readonly)) .jse-color-picker-button {
+.jse-color-picker-button:not(.jse-readonly) {
   cursor: pointer;
 }

--- a/src/lib/plugins/value/components/ColorPicker.scss
+++ b/src/lib/plugins/value/components/ColorPicker.scss
@@ -14,5 +14,8 @@
   border-radius: 2px;
   background: inherit;
   outline: none;
+}
+
+:global(.jse-json-node:not(.jse-readonly)) .jse-color-picker-button {
   cursor: pointer;
 }

--- a/src/lib/plugins/value/components/ColorPicker.svelte
+++ b/src/lib/plugins/value/components/ColorPicker.svelte
@@ -69,6 +69,7 @@
 <button
   type="button"
   class="jse-color-picker-button"
+  class:jse-readonly={readOnly}
   style="background: {color}"
   title={!readOnly ? 'Click to open a color picker' : `Color ${value}`}
   on:click={openColorPicker}


### PR DESCRIPTION
- Color Picker should not show `cursor: pointer` in text-only mode

- Boolean Toggle should show `cursor: pointer` in non-text-only mode
  > I'm not sure if this one is intended. But I decide to make this change after I took a look at [Svelte Material UI](https://sveltematerialui.com/demo/checkbox/), [Vuetify](https://next.vuetifyjs.com/en/components/checkboxes/), etc. Giving `cursor: pointer` to checkbox should be user friendly.