### PR TITLE
fix: unexpected scrollbar and gap in text mode

### DIFF
--- a/src/lib/components/modes/textmode/TextMode.scss
+++ b/src/lib/components/modes/textmode/TextMode.scss
@@ -32,13 +32,13 @@
 
     :global(.cm-editor) {
       flex: 1;
-      overflow: hidden;
 
       :global(.cm-scroller) {
         font-family: var(--jse-font-family-mono);
         font-size: var(--jse-font-size-mono);
         line-height: var(--jse-line-height);
         color: var(--jse-delimiter-color);
+        overflow: hidden;
       }
 
       :global(.cm-gutters) {


### PR DESCRIPTION
As shown in the figure:

![1667803255473](https://user-images.githubusercontent.com/31238760/200242409-88662b4c-75a6-47bf-bd5f-3fd5f75ea537.jpg)