### PR TITLE
build: offer UMD format output for 'vanilla-jsoneditor'

### DIFF
--- a/tools/createVanillaPackageJson.js
+++ b/tools/createVanillaPackageJson.js
@@ -4,12 +4,20 @@ import path from 'path'
 import { readFileSync, writeFileSync } from 'fs'
 import { getAbsolutePath } from './getAbsolutePath.mjs'
 import { getFilesRecursively } from './getFilesRecursively.js'
+import { packageFolder, name, moduleFile as module, umdFile as main } from '../rollup.config.bundle.js'
 
-const vanillaPackageFolder = getAbsolutePath(import.meta.url, '..', 'package-vanilla')
+const vanillaPackageFolder = getAbsolutePath(import.meta.url, '..', packageFolder)
 
 // collect all file names and generate the exports map for package.json
 const exports = {
-  '.': './index.js'
+  '.': {
+    'browser': {
+      'import': './' + module,
+      'require': './' + main
+    },
+    'import': './' + module,
+    'require': './' + main
+  },
 }
 const filenames = getFilesRecursively(vanillaPackageFolder).concat([
   path.join(vanillaPackageFolder, 'package.json')
@@ -23,7 +31,9 @@ filenames.forEach((filename) => {
 const pkg = JSON.parse(String(readFileSync(getAbsolutePath(import.meta.url, '..', 'package.json'))))
 const vanillaPackage = {
   ...pkg,
-  name: 'vanilla-jsoneditor',
+  module,
+  main,
+  name,
   scripts: {},
   dependencies: {},
   devDependencies: {},


### PR DESCRIPTION
Hi there. 👋

At present 'vanilla-jsoneditor' only provides ES format output which cannot handle situations like:
1. CDN usage in not-that-new browsers (Chrome ≤61), see https://caniuse.com/es6-module.
2. CommonJS environment.

CDN usage support is meaningful, see: 
- https://github.com/cloydlau/json-editor-vue/issues/5
- https://github.com/josdejong/svelte-jsoneditor/issues/53

If one dependency is ES format, it compels other dependencies to use the same way (native ES modules), which makes it quite messy, see https://github.com/cloydlau/json-editor-vue#cdn-2.

I made a sheet about what output formats are provided and what do they name it by popular libs:

| lib                            | es                           | umd                           | cjs                     | iife                 |
| ------------------------------ | ---------------------------- | ----------------------------- | ----------------------- | -------------------- |
| libs using Vite Default Config | `xxx.mjs`                    | `xxx.umd.js`                  | -                       | -                    |
| Svelte                         | `index.mjs`                  | -                             | `index.js`              | -                    |
| Vue                            | `vue.runtime.esm-bundler.js` | -                             | `vue.cjs.prod.js`       | `vue.global.prod.js` |
| React                          | -                            | `umd/react.production.min.js` | `index.js`              | -                    |
| Rollup                         | `es/rollup.js`               | -                             | `rollup.js`             | -                    |
| Axios                          | `esm/axios.min.js`           | `axios.min.js`                | `node/axios.cjs`        | -                    |
| ECharts                        | `echarts.esm.min.js`         | `echarts.min.js`              | `echarts.common.min.js` | -                    |
| Day.js                         | `esm/index.js`               | `dayjs.min.js`                | -                       | -                    |
| CodeMirror                     | `index.js`                   | -                             | `index.cjs`             | -                    |

We can see that no one is left CommonJS behind, which is provided by .cjs itself, UMD or both.

What do you think? If you agree with this:
1. What file name of UMD output should be? Now I tentatively name as `index.umd.js`.
2. Since we have two outputs now, should we change the file name of ES output too?