### PR TITLE
ci: setup Release GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: latest
+
+      - run: npx changelogithub
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Hello,

How about setting up a Release GitHub Action?

Motivation:

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Release Notification:

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img width="50%" src="https://user-images.githubusercontent.com/31238760/226380052-7ca57899-7ab4-439a-a968-d1ddf0e8b4cf.png">

- Wrapper author like me and whoever interested will immediately get notified when new versions released. I rely on this to ensure `json-editor-vue` catches up with the breaking changes of `svelte-jsoneditor` in time. It's very important to downstream ecology. (We can see 7 people are already watching)

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Without Release GitHub Action:

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img width="90%" src="https://user-images.githubusercontent.com/31238760/226385304-65e72fe7-102b-407f-8824-8efca93f040e.png">

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;With Release GitHub Action:

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img width="90%" src="https://user-images.githubusercontent.com/31238760/226380957-e5b87560-d6eb-4d87-92d0-0f7a1817a1df.png">

- As we can see versions are displayed more clearly rather than hiding in tags or CHANGELOG.md.
- Don't worry about the release notes, [changelogithub](https://github.com/antfu/changelogithub) will do the job.