### PR TITLE
feat: add indentation on wrapped lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@replit/codemirror-indentation-markers": "6.4.3",
         "ajv": "^8.12.0",
+        "codemirror-wrapped-line-indent": "^0.0.2",
         "diff-sequences": "^29.6.3",
         "immutable-json-patch": "^5.1.3",
         "jmespath": "^0.16.0",
@@ -1879,12 +1880,12 @@
       "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw=="
     },
     "node_modules/@codemirror/view": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.16.0.tgz",
-      "integrity": "sha512-1Z2HkvkC3KR/oEZVuW9Ivmp8TWLzGEd8T8TA04TTwPvqogfkHBdYSlflytDOqmkUxM2d1ywTg7X2dU5mC+SXvg==",
+      "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.17.1.tgz",
+      "integrity": "sha512-I5KVxsLbm1f56n9SUajLW0/AzMXYEZVvkiYahMw/yGl5gUjT2WquuKO39xUtiT4z/hNhGD7YuAEVPI8u0mncaQ==",
       "dependencies": {
         "@codemirror/state": "^6.1.4",
-        "style-mod": "^4.0.0",
+        "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
     },
@@ -5106,6 +5107,16 @@
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/codemirror-wrapped-line-indent": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror-wrapped-line-indent/-/codemirror-wrapped-line-indent-0.0.2.tgz",
+      "integrity": "sha512-nURSUnd7NGO+eVty5R9RKGIdgcGP3SRz1ofjG7wN0IRsEETEyV8LqdrxWSeE3JFAy0CtavjLR3jttOD2co9LDg==",
+      "peerDependencies": {
+        "@codemirror/language": "^6.9.0",
+        "@codemirror/state": "^6.2.1",
+        "@codemirror/view": "^6.17.1"
       }
     },
     "node_modules/color-convert": {
@@ -11897,9 +11908,9 @@
       }
     },
     "node_modules/style-mod": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
+      "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -14483,12 +14494,12 @@
       "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw=="
     },
     "@codemirror/view": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.16.0.tgz",
-      "integrity": "sha512-1Z2HkvkC3KR/oEZVuW9Ivmp8TWLzGEd8T8TA04TTwPvqogfkHBdYSlflytDOqmkUxM2d1ywTg7X2dU5mC+SXvg==",
+      "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.17.1.tgz",
+      "integrity": "sha512-I5KVxsLbm1f56n9SUajLW0/AzMXYEZVvkiYahMw/yGl5gUjT2WquuKO39xUtiT4z/hNhGD7YuAEVPI8u0mncaQ==",
       "requires": {
         "@codemirror/state": "^6.1.4",
-        "style-mod": "^4.0.0",
+        "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
     },
@@ -16727,6 +16738,12 @@
           }
         }
       }
+    },
+    "codemirror-wrapped-line-indent": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror-wrapped-line-indent/-/codemirror-wrapped-line-indent-0.0.2.tgz",
+      "integrity": "sha512-nURSUnd7NGO+eVty5R9RKGIdgcGP3SRz1ofjG7wN0IRsEETEyV8LqdrxWSeE3JFAy0CtavjLR3jttOD2co9LDg==",
+      "requires": {}
     },
     "color-convert": {
       "version": "1.9.3",
@@ -21727,9 +21744,9 @@
       }
     },
     "style-mod": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
+      "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@replit/codemirror-indentation-markers": "6.4.3",
     "ajv": "^8.12.0",
+    "codemirror-wrapped-line-indent": "^0.0.2",
     "diff-sequences": "^29.6.3",
     "immutable-json-patch": "^5.1.3",
     "jmespath": "^0.16.0",

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -115,6 +115,7 @@
   import { faJSONEditorFormat } from '$lib/img/customFontawesomeIcons.js'
   import { indentationMarkers } from '@replit/codemirror-indentation-markers'
   import { isTextSelection } from '$lib/logic/selection.js'
+  import { wrappedLineIndent } from 'codemirror-wrapped-line-indent'
 
   export let readOnly: boolean
   export let mainMenuBar: boolean
@@ -594,7 +595,8 @@
         tabSizeCompartment.of(EditorState.tabSize.of(tabSize)),
         indentUnitCompartment.of(createIndentUnit(indentation)),
         themeCompartment.of(EditorView.theme({}, { dark: hasDarkTheme() })),
-        EditorView.lineWrapping
+        EditorView.lineWrapping,
+        wrappedLineIndent
       ]
     })
 
@@ -748,7 +750,7 @@
     }
 
     const codeMirrorText = getCodeMirrorValue()
-
+    
     const isChanged = codeMirrorText !== text
     debug('onChangeCodeMirrorValue', { isChanged })
     if (!isChanged) {


### PR DESCRIPTION
resolves #228

Hi, in this PR, I've created a custom decoration to add 'padding-left' and 'text-indent' to each line so that the wrapped lines also have indentation.
I used '@replit/codemirror-indentation-markers' as a reference to build this decoration and even copied one of their utility functions, getVisibleLines.
I'm not sure if I put the file in the correct directory, nor am I sure what tests I should do to ensure that I don't break anything. If you can advice, that would be great

![image](https://github.com/josdejong/svelte-jsoneditor/assets/43085033/805ee48d-3e03-4e83-ba45-e82216fa6cf6)
