### PR TITLE
fix: export missing types

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
 import type { JSONPatchDocument, JSONPath, JSONValue } from 'immutable-json-patch'
 import type { SvelteComponent } from 'svelte'
 import type { IconDefinition } from '@fortawesome/free-solid-svg-icons'
+export type { JSONValue, JSONPath }
 
 export type TextContent = { text: string } | { json: undefined; text: string }
 
@@ -112,7 +113,7 @@ export interface TextSelection {
 
 export type JSONEditorSelection = JSONSelection | TextSelection
 
-type JSONPointer = string // Would like to use "import type { JSONPointer } from 'immutable-json-patch'" but that gives compile warnings
+export type JSONPointer = string // Would like to use "import type { JSONPointer } from 'immutable-json-patch'" but that gives compile warnings
 export type JSONPointerMap<T> = { [pointer: JSONPointer]: T }
 
 export type ClipboardValues = Array<{ key: string; value: JSONValue }>


### PR DESCRIPTION
Hi, thank you for the `v0.18.0` release 🙏

We have noticed some typescript errors when bumping `vanilla-jsoneditor` to the latest release.

Specifically, there seems to be issues with some missing types which aren't exported anymore.

```
node_modules/vanilla-jsoneditor/index.d.ts:102:15 - error TS2552: Cannot find name 'JSONPointer'. Did you mean 'JSONPointerMap'?

102     [pointer: JSONPointer]: T;
                  ~~~~~~~~~~~

node_modules/vanilla-jsoneditor/index.d.ts:682:15 - error TS2552: Cannot find name 'JSONPath'. Did you mean 'JSONPath$1'?

682         path: JSONPath;
                  ~~~~~~~~

node_modules/vanilla-jsoneditor/index.d.ts:683:16 - error TS2552: Cannot find name 'JSONValue'. Did you mean 'JSONValue$1'?

683         value: JSONValue;
                   ~~~~~~~~~
```

I guess the issues were caused by this change: https://github.com/josdejong/svelte-jsoneditor/commit/4d0451e981f3d6bc10ca338ed5c03b5b9a4f51fd#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5L5