### PR TITLE
fix: scope theme variables

### DIFF
--- a/src/lib/themes/jse-theme-dark.css
+++ b/src/lib/themes/jse-theme-dark.css
@@ -1,4 +1,5 @@
-.jse-theme-dark {
+.jse-theme-dark .jse-main,
+.jse-theme-dark .jse-main + .jse-absolute-popup {
   --jse-theme: dark;
 
   /* over all fonts, sizes, and colors */

--- a/src/lib/themes/jse-theme-default.css
+++ b/src/lib/themes/jse-theme-default.css
@@ -1,4 +1,4 @@
-:root {
+.jse-main {
   --jse-theme: light;
 
   /* over all fonts, sizes, and colors */

--- a/src/lib/themes/jse-theme-default.css
+++ b/src/lib/themes/jse-theme-default.css
@@ -1,4 +1,5 @@
-.jse-main {
+.jse-main,
+.jse-main + :global(.jse-absolute-popup) {
   --jse-theme: light;
 
   /* over all fonts, sizes, and colors */


### PR DESCRIPTION
Tested it via `npm run dev` and then doing a visual inspection.

This doesn't change the HTML structure, which is good, however it might break external theme modifications due to selector specificity. 
Ie someone having their own variables in `:root` vs us having the defaults in `.jse-main`. According to the specificity calculator (https://specificity.keegan.st/) it should be fine. Since specificity is equal it is just about ordering.
