### PR TITLE
Change the type of `json` from `JSONValue` to `unknown`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Or one-way binding:
   }
 
   function handleChange(updatedContent, previousContent, { contentErrors, patchResult }) {
-    // content is an object { json: JSONValue } | { text: string }
+    // content is an object { json: unknown } | { text: string }
     console.log('onChange: ', { updatedContent, previousContent, contentErrors, patchResult })
     content = updatedContent
   }
@@ -151,7 +151,7 @@ Browser example loading the standalone ES module:
         props: {
           content,
           onChange: (updatedContent, previousContent, { contentErrors, patchResult }) => {
-            // content is an object { json: JSONValue } | { text: string }
+            // content is an object { json: unknown } | { text: string }
             console.log('onChange', { updatedContent, previousContent, contentErrors, patchResult })
             content = updatedContent
           }
@@ -203,7 +203,7 @@ const editor = new JSONEditor({
   props: {
     content,
     onChange: (updatedContent, previousContent, { contentErrors, patchResult }) => {
-      // content is an object { json: JSONValue } | { text: string }
+      // content is an object { json: unknown } | { text: string }
       console.log('onChange', { updatedContent, previousContent, contentErrors, patchResult })
     }
   }
@@ -225,7 +225,7 @@ const editor = new JSONEditor({
 - `escapeControlCharacters: boolean`. False by default. When `true`, control characters like newline and tab are rendered as escaped characters `\n` and `\t`. Only applicable for `'tree'` mode, in `'text'` mode control characters are always escaped.
 - `escapeUnicodeCharacters: boolean`. False by default. When `true`, unicode characters like ☎ and 😀 are rendered escaped like `\u260e` and `\ud83d\ude00`.
 - `flattenColumns: boolean`. True by default. Only applicable to `'table'` mode. When `true`, nested object properties will be displayed each in their own column, with the nested path as column name. When `false`, nested objects will be rendered inline, and double-clicking them will open them in a popup.
-- `validator: function (json: JSONValue): ValidationError[]`. Validate the JSON document.
+- `validator: function (json: unknown): ValidationError[]`. Validate the JSON document.
   For example use the built-in JSON Schema validator powered by Ajv:
 
   ```js
@@ -438,7 +438,7 @@ Note that most methods are asynchronous and will resolve after the editor is re-
   - `editor.expand(path => true)` expand all
   - `editor.expand(path => false)` collapse all
   - `editor.expand(path => path.length < 2)` expand all paths up to 2 levels deep
-- `transform({ id?: string, rootPath?: [], onTransform: ({ operations: JSONPatchDocument, json: JSONValue, transformedJson: JSONValue }) => void, onClose: () => void })` programmatically trigger clicking of the transform button in the main menu, opening the transform model. If a callback `onTransform` is provided, it will replace the build-in logic to apply a transform, allowing you to process the transform operations in an alternative way. If provided, `onClose` callback will trigger when the transform modal closes, both after the user clicked apply or cancel. If an `id` is provided, the transform modal will load the previous status of this `id` instead of the status of the editors transform modal.
+- `transform({ id?: string, rootPath?: [], onTransform: ({ operations: JSONPatchDocument, json: unknown, transformedJson: unknown }) => void, onClose: () => void })` programmatically trigger clicking of the transform button in the main menu, opening the transform model. If a callback `onTransform` is provided, it will replace the build-in logic to apply a transform, allowing you to process the transform operations in an alternative way. If provided, `onClose` callback will trigger when the transform modal closes, both after the user clicked apply or cancel. If an `id` is provided, the transform modal will load the previous status of this `id` instead of the status of the editors transform modal.
 - `scrollTo(path: Path): Promise<void>` Scroll the editor vertically such that the specified path comes into view. Only applicable to modes `tree` and `table`. The path will be expanded when needed. The returned Promise is resolved after scrolling is finished.
 - `findElement(path: Path)` Find the DOM element of a given path. Returns `null` when not found.
 - `acceptAutoRepair(): Promise<Content>` In tree mode, invalid JSON is automatically repaired when loaded. When the repair was successful, the repaired contents are rendered but not yet applied to the document itself until the user clicks "Ok" or starts editing the data. Instead of accepting the repair, the user can also click "Repair manually instead". Invoking `.acceptAutoRepair()` will programmatically accept the repair. This will trigger an update, and the method itself also returns the updated contents. In case of `text` mode or when the editor is not in an "accept auto repair" status, nothing will happen, and the contents will be returned as is.

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "eslint-plugin-svelte": "2.35.1",
         "husky": "8.0.3",
         "jsdom": "23.0.1",
-        "lossless-json": "3.0.2",
+        "lossless-json": "4.0.1",
         "npm-run-all": "4.1.5",
         "prettier": "3.1.0",
         "prettier-plugin-svelte": "3.1.2",
@@ -10681,9 +10681,9 @@
       "dev": true
     },
     "node_modules/lossless-json": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-3.0.2.tgz",
-      "integrity": "sha512-IbNz6s05hNuQjIC3DL15ahu3S5V7AQAjMnjNGfucqW+r17XQN6CwmAwU2LU2KAJkfaVu/4A7gmlCMrq/ch4wug==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.0.1.tgz",
+      "integrity": "sha512-l0L+ppmgPDnb+JGxNLndPtJZGNf6+ZmVaQzoxQm3u6TXmhdnsA+YtdVR8DjzZd/em58686CQhOFDPewfJ4l7MA==",
       "dev": true
     },
     "node_modules/loupe": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "eslint-plugin-svelte": "2.35.1",
     "husky": "8.0.3",
     "jsdom": "23.0.1",
-    "lossless-json": "3.0.2",
+    "lossless-json": "4.0.1",
     "npm-run-all": "4.1.5",
     "prettier": "3.1.0",
     "prettier-plugin-svelte": "3.1.2",

--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -132,8 +132,9 @@
       debug('parser changed, recreate editor')
 
       if (isJSONContent(content)) {
+        const text = previousParser.stringify(content.json)
         content = {
-          json: parser.parse(previousParser.stringify(content.json))
+          json: text !== undefined ? parser.parse(text) : undefined
         }
       }
 

--- a/src/lib/components/controls/JSONPreview.svelte
+++ b/src/lib/components/controls/JSONPreview.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import type { JSONParser, JSONValue } from '$lib/types'
+  import type { JSONParser } from '$lib/types'
   import { truncate } from '$lib/utils/stringUtils.js'
   import { getText } from '$lib/utils/jsonUtils.js'
   import { MAX_CHARACTERS_TEXT_PREVIEW } from '$lib/constants.js'
 
   export let text: string | undefined
-  export let json: JSONValue | undefined
+  export let json: unknown | undefined
   export let indentation: number | string
   export let parser: JSONParser
 

--- a/src/lib/components/controls/navigationBar/NavigationBar.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBar.svelte
@@ -8,13 +8,7 @@
   import { createMultiSelection, getFocusPath } from '$lib/logic/selection.js'
   import { createDebug } from '$lib/utils/debug.js'
   import { caseInsensitiveNaturalCompare } from '$lib/logic/sort.js'
-  import type {
-    JSONPathParser,
-    JSONSelection,
-    JSONValue,
-    OnError,
-    OnJSONSelect
-  } from '$lib/types.js'
+  import type { JSONPathParser, JSONSelection, OnError, OnJSONSelect } from '$lib/types.js'
   import Icon from 'svelte-awesome'
   import { faClose, faEdit } from '@fortawesome/free-solid-svg-icons'
   import NavigationBarItem from './NavigationBarItem.svelte'
@@ -22,7 +16,7 @@
 
   const debug = createDebug('jsoneditor:NavigationBar')
 
-  export let json: JSONValue
+  export let json: unknown
   export let selection: JSONSelection | null
   export let onSelect: OnJSONSelect
   export let onError: OnError

--- a/src/lib/components/controls/tooltip/tooltip.ts
+++ b/src/lib/components/controls/tooltip/tooltip.ts
@@ -5,7 +5,7 @@ import type { AbsolutePopupOptions } from '$lib/types'
 export interface TooltipOptions {
   text: string
   openAbsolutePopup: (
-    component: typeof SvelteComponent,
+    component: typeof SvelteComponent<Record<string, unknown>>,
     props: Record<string, unknown>,
     options: AbsolutePopupOptions
   ) => number

--- a/src/lib/components/modals/SortModal.svelte
+++ b/src/lib/components/modals/SortModal.svelte
@@ -12,14 +12,14 @@
   import type { JSONPath } from 'immutable-json-patch'
   import { compileJSONPointer, getIn } from 'immutable-json-patch'
   import { createDebug } from '$lib/utils/debug.js'
-  import type { JSONValue, OnSort } from '$lib/types.js'
+  import type { OnSort } from '$lib/types.js'
   import { onEscape } from '$lib/actions/onEscape.js'
   import type { Context } from 'svelte-simple-modal'
 
   const debug = createDebug('jsoneditor:SortModal')
 
   export let id: string
-  export let json: JSONValue // the whole document
+  export let json: unknown // the whole document
   export let rootPath: JSONPath
   export let onSort: OnSort
 

--- a/src/lib/components/modals/TransformModal.svelte
+++ b/src/lib/components/modals/TransformModal.svelte
@@ -20,7 +20,6 @@
     Content,
     JSONParser,
     JSONPathParser,
-    JSONValue,
     OnChangeQueryLanguage,
     OnClassName,
     OnPatch,
@@ -34,7 +33,7 @@
   const debug = createDebug('jsoneditor:TransformModal')
 
   export let id = 'transform-modal-' + uniqueId()
-  export let json: JSONValue
+  export let json: unknown
   export let rootPath: JSONPath = []
 
   export let indentation: number | string
@@ -54,7 +53,7 @@
 
   export let onTransform: OnPatch
 
-  let selectedJson: JSONValue | undefined
+  let selectedJson: unknown | undefined
   $: selectedJson = getIn(json, rootPath)
   let selectedContent: Content
   $: selectedContent = selectedJson ? { json: selectedJson } : { text: '' }
@@ -97,7 +96,7 @@
     debug('handleChangeQuery', { query, isManual })
   }
 
-  function previewTransform(json: JSONValue | undefined, query: string) {
+  function previewTransform(json: unknown | undefined, query: string) {
     if (json === undefined) {
       previewContent = { text: '' }
       previewError = 'Error: No JSON'

--- a/src/lib/components/modals/TransformWizard.svelte
+++ b/src/lib/components/modals/TransformWizard.svelte
@@ -8,7 +8,7 @@
   import { isEqual } from 'lodash-es'
   import type { JSONPath } from 'immutable-json-patch'
   import { setIn } from 'immutable-json-patch'
-  import type { QueryLanguageOptions } from '$lib/types.js'
+  import type { PathOption, QueryLanguageOptions } from '$lib/types.js'
 
   const debug = createDebug('jsoneditor:TransformWizard')
 
@@ -48,10 +48,10 @@
     queryOptions?.projection?.paths && projectionOptions
       ? queryOptions.projection.paths
           .map((path) => projectionOptions.find((option) => isEqual(option.value, path)))
-          .filter((option) => !!option)
+          .filter((option) => !!option) as PathOption[]
       : null
 
-  function changeFilterPath(path: JSONPath) {
+  function changeFilterPath(path: JSONPath | undefined) {
     if (!isEqual(queryOptions?.filter?.path, path)) {
       debug('changeFilterPath', path)
       queryOptions = setIn(queryOptions, ['filter', 'path'], path, true)
@@ -59,7 +59,7 @@
     }
   }
 
-  function changeFilterRelation(relation) {
+  function changeFilterRelation(relation: string | undefined) {
     if (!isEqual(queryOptions?.filter?.relation, relation)) {
       debug('changeFilterRelation', relation)
       queryOptions = setIn(queryOptions, ['filter', 'relation'], relation, true)
@@ -67,7 +67,7 @@
     }
   }
 
-  function changeFilterValue(value) {
+  function changeFilterValue(value: string | undefined) {
     if (!isEqual(queryOptions?.filter?.value, value)) {
       debug('changeFilterValue', value)
       queryOptions = setIn(queryOptions, ['filter', 'value'], value, true)
@@ -75,7 +75,7 @@
     }
   }
 
-  function changeSortPath(path) {
+  function changeSortPath(path: JSONPath | undefined) {
     if (!isEqual(queryOptions?.sort?.path, path)) {
       debug('changeSortPath', path)
       queryOptions = setIn(queryOptions, ['sort', 'path'], path, true)
@@ -83,7 +83,7 @@
     }
   }
 
-  function changeSortDirection(direction) {
+  function changeSortDirection(direction: string | undefined) {
     if (!isEqual(queryOptions?.sort?.direction, direction)) {
       debug('changeSortDirection', direction)
       queryOptions = setIn(queryOptions, ['sort', 'direction'], direction, true)
@@ -91,7 +91,7 @@
     }
   }
 
-  function changeProjectionPaths(paths) {
+  function changeProjectionPaths(paths: JSONPath[] | unknown) {
     if (!isEqual(queryOptions?.projection?.paths, paths)) {
       debug('changeProjectionPaths', paths)
       queryOptions = setIn(queryOptions, ['projection', 'paths'], paths, true)
@@ -99,12 +99,12 @@
     }
   }
 
-  $: changeFilterPath(filterPath?.value || null)
-  $: changeFilterRelation(filterRelation?.value || null)
-  $: changeFilterValue(filterValue || null)
-  $: changeSortPath(sortPath?.value || null)
-  $: changeSortDirection(sortDirection?.value || null)
-  $: changeProjectionPaths(projectionPaths ? projectionPaths.map((item) => item.value) : null)
+  $: changeFilterPath(filterPath?.value)
+  $: changeFilterRelation(filterRelation?.value )
+  $: changeFilterValue(filterValue)
+  $: changeSortPath(sortPath?.value )
+  $: changeSortDirection(sortDirection?.value)
+  $: changeProjectionPaths(projectionPaths ? projectionPaths.map((item) => item.value) : undefined)
 </script>
 
 <table class="jse-transform-wizard">

--- a/src/lib/components/modals/TransformWizard.svelte
+++ b/src/lib/components/modals/TransformWizard.svelte
@@ -46,9 +46,9 @@
 
   $: projectionPaths =
     queryOptions?.projection?.paths && projectionOptions
-      ? queryOptions.projection.paths
+      ? (queryOptions.projection.paths
           .map((path) => projectionOptions.find((option) => isEqual(option.value, path)))
-          .filter((option) => !!option) as PathOption[]
+          .filter((option) => !!option) as PathOption[])
       : null
 
   function changeFilterPath(path: JSONPath | undefined) {
@@ -100,9 +100,9 @@
   }
 
   $: changeFilterPath(filterPath?.value)
-  $: changeFilterRelation(filterRelation?.value )
+  $: changeFilterRelation(filterRelation?.value)
   $: changeFilterValue(filterValue)
-  $: changeSortPath(sortPath?.value )
+  $: changeSortPath(sortPath?.value)
   $: changeSortDirection(sortDirection?.value)
   $: changeProjectionPaths(projectionPaths ? projectionPaths.map((item) => item.value) : undefined)
 </script>

--- a/src/lib/components/modals/TransformWizard.svelte
+++ b/src/lib/components/modals/TransformWizard.svelte
@@ -8,11 +8,11 @@
   import { isEqual } from 'lodash-es'
   import type { JSONPath } from 'immutable-json-patch'
   import { setIn } from 'immutable-json-patch'
-  import type { JSONValue, QueryLanguageOptions } from '$lib/types.js'
+  import type { QueryLanguageOptions } from '$lib/types.js'
 
   const debug = createDebug('jsoneditor:TransformWizard')
 
-  export let json: JSONValue
+  export let json: unknown
   export let queryOptions: QueryLanguageOptions = {}
   export let onChange: (queryOptions: QueryLanguageOptions) => void
 

--- a/src/lib/components/modes/tablemode/JSONValue.svelte
+++ b/src/lib/components/modes/tablemode/JSONValue.svelte
@@ -5,7 +5,6 @@
     AfterPatchCallback,
     JSONEditorContext,
     JSONSelection,
-    JSONValue,
     SearchResultItem
   } from '$lib/types'
   import type { JSONPatchDocument, JSONPath } from 'immutable-json-patch'
@@ -13,7 +12,7 @@
   import { createNestedValueOperations } from '$lib/logic/operations.js'
 
   export let path: JSONPath
-  export let value: JSONValue
+  export let value: unknown
   export let context: JSONEditorContext
   export let enforceString: boolean
   export let selection: JSONSelection | null

--- a/src/lib/components/modes/tablemode/TableMode.svelte
+++ b/src/lib/components/modes/tablemode/TableMode.svelte
@@ -15,7 +15,6 @@
     JSONParser,
     JSONPatchResult,
     JSONSelection,
-    JSONValue,
     OnBlur,
     OnChange,
     OnChangeMode,
@@ -207,7 +206,7 @@
     }
   })
 
-  let json: JSONValue | undefined
+  let json: unknown | undefined
   let text: string | undefined
   let parseError: ParseError | undefined = undefined
 
@@ -248,7 +247,7 @@
   $: refreshScrollTop(json)
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  function refreshScrollTop(_json: JSONValue | undefined) {
+  function refreshScrollTop(_json: unknown | undefined) {
     // When the contents go from lots of items and scrollable contents to only a few items and
     // no vertical scroll, the actual scrollTop changes to 0 but there is no on:scroll event
     // triggered, so the internal scrollTop variable is not up-to-date.
@@ -291,7 +290,7 @@
     }
   }
 
-  function clearSelectionWhenNotExisting(json: JSONValue | undefined) {
+  function clearSelectionWhenNotExisting(json: unknown | undefined) {
     if (!documentState.selection || json === undefined) {
       return
     }
@@ -443,7 +442,7 @@
     previousText,
     previousTextIsRepaired
   }: {
-    previousJson: JSONValue | undefined
+    previousJson: unknown | undefined
     previousText: string | undefined
     previousState: DocumentState
     previousTextIsRepaired: boolean
@@ -523,7 +522,7 @@
   const memoizedValidate = memoizeOne(validateJSON)
 
   function updateValidationErrors(
-    json: JSONValue,
+    json: unknown,
     validator: Validator | null,
     parser: JSONParser,
     validationParser: JSONParser
@@ -1074,7 +1073,7 @@
         {
           op: 'replace',
           path: pointer,
-          value: updatedValue as JSONValue
+          value: updatedValue
         }
       ],
       (patchedJson, patchedState) => {
@@ -1388,7 +1387,7 @@
   }
 
   // TODO: this function is duplicated from TreeMode. See if we can reuse the code instead
-  function handleReplaceJson(updatedJson: JSONValue, afterPatch?: AfterPatchCallback) {
+  function handleReplaceJson(updatedJson: unknown, afterPatch?: AfterPatchCallback) {
     const previousState = documentState
     const previousJson = json
     const previousText = text
@@ -1545,8 +1544,8 @@
         if (onTransform) {
           onTransform({
             operations,
-            json: json as JSONValue,
-            transformedJson: immutableJSONPatch(json as JSONValue, operations)
+            json: json,
+            transformedJson: immutableJSONPatch(json, operations)
           })
         } else {
           debug('onTransform', rootPath, operations)
@@ -1572,7 +1571,7 @@
     // open a popup where you can edit the nested object/array
     onJSONEditorModal({
       content: {
-        json: getIn(json as JSONValue, path) as JSONValue
+        json: getIn(json, path)
       },
       path,
       onPatch: context.onPatch,

--- a/src/lib/components/modes/tablemode/TableModeWelcome.svelte
+++ b/src/lib/components/modes/tablemode/TableModeWelcome.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import type { JSONPath } from 'immutable-json-patch'
   import { getIn, isJSONArray, isJSONObject } from 'immutable-json-patch'
-  import type { JSONParser, JSONValue, OnChangeMode } from '$lib/types.js'
+  import type { JSONParser, OnChangeMode } from '$lib/types.js'
   import { Mode } from '$lib/types.js'
   import { valueType } from '$lib/utils/typeUtils.js'
   import { findNestedArrays } from '$lib/logic/table.js'
@@ -11,7 +11,7 @@
   import { stringifyJSONPath } from '$lib/utils/pathUtils.js'
 
   export let text: string | undefined
-  export let json: JSONValue | undefined
+  export let json: unknown | undefined
   export let readOnly: boolean
   export let parser: JSONParser
   export let openJSONEditorModal: (path: JSONPath) => void

--- a/src/lib/components/modes/tablemode/contextmenu/TableContextMenu.svelte
+++ b/src/lib/components/modes/tablemode/contextmenu/TableContextMenu.svelte
@@ -24,13 +24,12 @@
     ContextMenuItem,
     DocumentState,
     JSONParser,
-    JSONValue,
     OnRenderContextMenuInternal
   } from '$lib/types'
   import { getEnforceString } from '$lib/logic/documentState.js'
   import ContextMenu from '../../../../components/controls/contextmenu/ContextMenu.svelte'
 
-  export let json: JSONValue | undefined
+  export let json: unknown | undefined
   export let documentState: DocumentState
   export let parser: JSONParser
 

--- a/src/lib/components/modes/tablemode/menu/TableMenu.svelte
+++ b/src/lib/components/modes/tablemode/menu/TableMenu.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import type { JSONValue, MenuItem, OnRenderMenuInternal } from '$lib/types'
+  import type { MenuItem, OnRenderMenuInternal } from '$lib/types'
   import Menu from '../../../controls/Menu.svelte'
   import {
     faEllipsisV,
@@ -13,7 +13,7 @@
   import type { HistoryState } from '$lib/logic/history'
   import { CONTEXT_MENU_EXPLANATION } from '$lib/constants.js'
 
-  export let json: JSONValue | undefined
+  export let json: unknown | undefined
   export let readOnly: boolean
   export let historyState: HistoryState
   export let onSort: () => void

--- a/src/lib/components/modes/tablemode/tag/InlineValue.svelte
+++ b/src/lib/components/modes/tablemode/tag/InlineValue.svelte
@@ -1,13 +1,13 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import type { JSONArray, JSONObject, JSONPath } from 'immutable-json-patch'
+  import type { JSONPath } from 'immutable-json-patch'
   import type { JSONParser } from '$lib/types'
   import { truncate } from '$lib/utils/stringUtils.js'
   import { MAX_INLINE_OBJECT_CHARS } from '$lib/constants.js'
 
   export let path: JSONPath
-  export let value: JSONArray | JSONObject
+  export let value: unknown
   export let parser: JSONParser
   export let isSelected: boolean
   export let onEdit: (path: JSONPath) => void
@@ -19,7 +19,7 @@
   class:jse-selected={isSelected}
   on:dblclick={() => onEdit(path)}
 >
-  {truncate(parser.stringify(value), MAX_INLINE_OBJECT_CHARS)}
+  {truncate(parser.stringify(value) ?? '', MAX_INLINE_OBJECT_CHARS)}
 </button>
 
 <style src="./InlineValue.scss"></style>

--- a/src/lib/components/modes/textmode/StatusBar.svelte
+++ b/src/lib/components/modes/textmode/StatusBar.svelte
@@ -3,17 +3,17 @@
 
   export let editorState: EditorState | undefined
 
-  let pos: number
+  let pos: number | undefined
   $: pos = editorState?.selection?.main?.head
 
-  let line: Line
-  $: line = editorState?.doc?.lineAt(pos)
+  let line: Line | undefined
+  $: line = pos ? editorState?.doc?.lineAt(pos) : undefined
 
   let lineNumber: number | undefined
   $: lineNumber = line ? line.number : undefined
 
   let columnNumber: number | undefined
-  $: columnNumber = line ? pos - line.from + 1 : undefined
+  $: columnNumber = line !==undefined && pos !== undefined ? pos - line.from + 1 : undefined
 
   let charCount: number | undefined
   $: charCount = editorState?.selection?.ranges?.reduce((count, range) => {

--- a/src/lib/components/modes/textmode/StatusBar.svelte
+++ b/src/lib/components/modes/textmode/StatusBar.svelte
@@ -13,7 +13,7 @@
   $: lineNumber = line ? line.number : undefined
 
   let columnNumber: number | undefined
-  $: columnNumber = line !==undefined && pos !== undefined ? pos - line.from + 1 : undefined
+  $: columnNumber = line !== undefined && pos !== undefined ? pos - line.from + 1 : undefined
 
   let charCount: number | undefined
   $: charCount = editorState?.selection?.ranges?.reduce((count, range) => {

--- a/src/lib/components/modes/treemode/JSONNode.svelte
+++ b/src/lib/components/modes/treemode/JSONNode.svelte
@@ -2,13 +2,7 @@
 
 <script lang="ts">
   import { faCaretDown, faCaretRight } from '@fortawesome/free-solid-svg-icons'
-  import type {
-    JSONArray,
-    JSONObject,
-    JSONPath,
-    JSONPointer,
-    JSONValue as JSONValueType
-  } from 'immutable-json-patch'
+  import type { JSONPath, JSONPointer } from 'immutable-json-patch'
   import { appendToJSONPointer, compileJSONPointer, parseJSONPointer } from 'immutable-json-patch'
   import { initial, isEqual, last } from 'lodash-es'
   import Icon from 'svelte-awesome'
@@ -79,7 +73,7 @@
   import { isObject } from '$lib/utils/typeUtils.js'
   import { classnames } from '$lib/utils/cssUtils.js'
 
-  export let value: JSONValueType
+  export let value: unknown
   export let path: JSONPath
   export let expandedMap: JSONPointerMap<boolean> | undefined
   export let enforceStringMap: JSONPointerMap<boolean> | undefined
@@ -125,7 +119,7 @@
   // TODO: extract getProps into a separate function
   function getProps(
     path: JSONPath,
-    object: JSONObject,
+    object: Record<string, unknown>,
     expandedMap: JSONPointerMap<boolean> | undefined,
     enforceStringMap: JSONPointerMap<boolean> | undefined,
     visibleSectionsMap: JSONPointerMap<VisibleSection[]> | undefined,
@@ -167,7 +161,7 @@
   // TODO: extract getItems into a separate function
   function getItems(
     path: JSONPath,
-    array: JSONArray,
+    array: Array<unknown>,
     visibleSection: VisibleSection,
     expandedMap: JSONPointerMap<boolean> | undefined,
     enforceStringMap: JSONPointerMap<boolean> | undefined,
@@ -233,7 +227,7 @@
   }
 
   function handleUpdateKey(oldKey: string, newKey: string): string {
-    const operations = rename(path, Object.keys(value as JSONObject), oldKey, newKey)
+    const operations = rename(path, Object.keys(value as Record<string, unknown>), oldKey, newKey)
     context.onPatch(operations)
 
     // It is possible that the applied key differs from newKey,
@@ -551,7 +545,7 @@
       forEachIndex(start, Math.min(value.length, end), (index) => addHeight(String(index)))
     } else {
       // value is Object
-      Object.keys(value as JSONObject).forEach(addHeight)
+      Object.keys(value as Record<string, unknown>).forEach(addHeight)
     }
 
     return items

--- a/src/lib/components/modes/treemode/JSONValue.svelte
+++ b/src/lib/components/modes/treemode/JSONValue.svelte
@@ -1,12 +1,12 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import type { JSONEditorContext, JSONSelection, JSONValue, SearchResultItem } from '$lib/types.js'
+  import type { JSONEditorContext, JSONSelection, SearchResultItem } from '$lib/types.js'
   import type { JSONPath } from 'immutable-json-patch'
   import { isEditingSelection, isValueSelection } from '$lib/logic/selection.js'
 
   export let path: JSONPath
-  export let value: JSONValue
+  export let value: unknown
   export let context: JSONEditorContext
   export let enforceString: boolean
   export let selection: JSONSelection | null

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -1441,9 +1441,14 @@
   function handlePatch(
     operations: JSONPatchDocument,
     afterPatch?: AfterPatchCallback
-  ): JSONPatchResult | null {
+  ): JSONPatchResult {
     if (readOnly) {
-      return null
+      return {
+        json,
+        previousJson: json,
+        undo: [],
+        redo: []
+      }
     }
 
     debug('handlePatch', operations, afterPatch)

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -121,7 +121,6 @@
     JSONPathParser,
     JSONPointerMap,
     JSONSelection,
-    JSONValue,
     NestedValidationError,
     OnBlur,
     OnChange,
@@ -229,7 +228,7 @@
     }
   })
 
-  let json: JSONValue | undefined
+  let json: unknown | undefined
   let text: string | undefined
   let parseError: ParseError | undefined = undefined
 
@@ -360,7 +359,7 @@
 
   // we pass searchText and json as argument to trigger search when these variables change,
   // via $: applySearchThrottled(searchText, json)
-  function applySearch(searchText: string, json: JSONValue) {
+  function applySearch(searchText: string, json: unknown) {
     if (searchText === '') {
       debug('clearing search result')
 
@@ -435,7 +434,7 @@
   const memoizedValidate = memoizeOne(validateJSON)
 
   function updateValidationErrors(
-    json: JSONValue,
+    json: unknown,
     validator: Validator | null,
     parser: JSONParser,
     validationParser: JSONParser
@@ -498,7 +497,7 @@
     }
   }
 
-  function applyExternalJson(updatedJson: JSONValue | undefined) {
+  function applyExternalJson(updatedJson: unknown | undefined) {
     if (updatedJson === undefined) {
       return
     }
@@ -618,14 +617,14 @@
     }
   }
 
-  function expandWhenNotInitialized(json: JSONValue) {
+  function expandWhenNotInitialized(json: unknown) {
     if (!documentStateInitialized) {
       documentStateInitialized = true
       documentState = expandWithCallback(json, documentState, [], getDefaultExpand(json))
     }
   }
 
-  function clearSelectionWhenNotExisting(json: JSONValue) {
+  function clearSelectionWhenNotExisting(json: unknown) {
     if (!documentState.selection) {
       return
     }
@@ -650,7 +649,7 @@
     previousText,
     previousTextIsRepaired
   }: {
-    previousJson: JSONValue | undefined
+    previousJson: unknown | undefined
     previousText: string | undefined
     previousState: DocumentState
     previousTextIsRepaired: boolean
@@ -851,7 +850,7 @@
         {
           op: 'replace',
           path: pointer,
-          value: updatedValue as JSONValue
+          value: updatedValue
         }
       ],
       (patchedJson, patchedState) => {
@@ -1051,7 +1050,7 @@
 
     try {
       const path = getAnchorPath(documentState.selection)
-      const currentValue: JSONValue = getIn(json, path)
+      const currentValue: unknown = getIn(json, path)
       const convertedValue = convertValue(currentValue, type, parser)
       if (convertedValue === currentValue) {
         // no change, do nothing
@@ -1271,8 +1270,8 @@
         if (onTransform) {
           onTransform({
             operations,
-            json: json as JSONValue,
-            transformedJson: immutableJSONPatch(json as JSONValue, operations)
+            json,
+            transformedJson: immutableJSONPatch(json, operations)
           })
         } else {
           debug('onTransform', rootPath, operations)
@@ -1313,7 +1312,7 @@
     })
   }
 
-  function openJSONEditorModal(path: JSONPath, value: JSONValue) {
+  function openJSONEditorModal(path: JSONPath, value: unknown) {
     debug('openJSONEditorModal', { path, value })
 
     modalOpen = true
@@ -1452,7 +1451,7 @@
     return patch(operations, afterPatch)
   }
 
-  function handleReplaceJson(updatedJson: JSONValue, afterPatch?: AfterPatchCallback) {
+  function handleReplaceJson(updatedJson: unknown, afterPatch?: AfterPatchCallback) {
     const previousState = documentState
     const previousJson = json
     const previousText = text

--- a/src/lib/components/modes/treemode/contextmenu/TreeContextMenu.svelte
+++ b/src/lib/components/modes/treemode/contextmenu/TreeContextMenu.svelte
@@ -33,13 +33,12 @@
     DocumentState,
     InsertType,
     JSONParser,
-    JSONValue,
     OnRenderContextMenuInternal
   } from '$lib/types'
   import { getEnforceString } from '$lib/logic/documentState.js'
   import ContextMenu from '../../../../components/controls/contextmenu/ContextMenu.svelte'
 
-  export let json: JSONValue
+  export let json: unknown
   export let documentState: DocumentState
   export let parser: JSONParser
 

--- a/src/lib/components/modes/treemode/menu/TreeMenu.svelte
+++ b/src/lib/components/modes/treemode/menu/TreeMenu.svelte
@@ -14,11 +14,11 @@
   import { faJSONEditorCollapse, faJSONEditorExpand } from '$lib/img/customFontawesomeIcons.js'
   import { isObjectOrArray } from '$lib/utils/typeUtils.js'
   import Menu from '../../../controls/Menu.svelte'
-  import type { JSONSelection, JSONValue, MenuItem, OnRenderMenuInternal } from '$lib/types'
+  import type { JSONSelection, MenuItem, OnRenderMenuInternal } from '$lib/types'
   import { isKeySelection, isMultiSelection, isValueSelection } from '$lib/logic/selection.js'
   import type { HistoryState } from '$lib/logic/history.js'
 
-  export let json: JSONValue
+  export let json: unknown
   export let selection: JSONSelection | null
 
   export let readOnly: boolean

--- a/src/lib/logic/actions.ts
+++ b/src/lib/logic/actions.ts
@@ -511,7 +511,7 @@ export function onInsert({
   const newValue = createNewValue(json, selection, insertType)
 
   if (json !== undefined) {
-    const data = parser.stringify(newValue)
+    const data = parser.stringify(newValue) as string
     const operations = insert(json, selection, data, parser)
     debug('onInsert', { insertType, operations, newValue, data })
 

--- a/src/lib/logic/actions.ts
+++ b/src/lib/logic/actions.ts
@@ -24,10 +24,8 @@ import type {
   AfterPatchCallback,
   DocumentState,
   InsertType,
-  JSONArray,
   JSONParser,
   JSONSelection,
-  JSONValue,
   OnChange,
   OnChangeText,
   OnJSONSelect,
@@ -56,7 +54,7 @@ import { fromTableCellPosition, toTableCellPosition } from '$lib/logic/table.js'
 const debug = createDebug('jsoneditor:actions')
 
 export interface OnCutAction {
-  json: JSONValue | undefined
+  json: unknown | undefined
   documentState: DocumentState
   indentation: string | number | undefined
   readOnly: boolean
@@ -102,7 +100,7 @@ export async function onCut({
 }
 
 export interface OnCopyAction {
-  json: JSONValue
+  json: unknown
   documentState: DocumentState
   indentation: string | number | undefined
   parser: JSONParser
@@ -124,7 +122,7 @@ type RepairModalCallback = (text: string, onApply: (repairedText: string) => voi
 
 interface OnPasteAction {
   clipboardText: string
-  json: JSONValue | undefined
+  json: unknown | undefined
   selection: JSONSelection | null
   readOnly: boolean
   parser: JSONParser
@@ -201,7 +199,7 @@ export function onPaste({
 }
 
 export interface OnRemoveAction {
-  json: JSONValue | undefined
+  json: unknown | undefined
   text: string | undefined
   documentState: DocumentState
   keepSelection: boolean
@@ -264,7 +262,7 @@ export function onRemove({
 }
 
 export interface OnDuplicateRowAction {
-  json: JSONValue | undefined
+  json: unknown | undefined
   documentState: DocumentState
   columns: JSONPath[]
   readOnly: boolean
@@ -303,7 +301,7 @@ export function onDuplicateRow({
   const operations = duplicate(json, [rowPath])
 
   onPatch(operations, (patchedJson, patchedState) => {
-    const newRowIndex = rowIndex < (json as JSONArray).length ? rowIndex + 1 : rowIndex
+    const newRowIndex = rowIndex < (json as Array<unknown>).length ? rowIndex + 1 : rowIndex
     const newPath = fromTableCellPosition({ rowIndex: newRowIndex, columnIndex }, columns)
     const newSelection = createValueSelection(newPath, false)
 
@@ -317,7 +315,7 @@ export function onDuplicateRow({
 }
 
 export interface OnInsertBeforeRowAction {
-  json: JSONValue | undefined
+  json: unknown | undefined
   documentState: DocumentState
   columns: JSONPath[]
   readOnly: boolean
@@ -350,7 +348,7 @@ export function onInsertBeforeRow({
   debug('insert before row', { rowIndex })
 
   const rowPath = [String(rowIndex)]
-  const newValue = isJSONObject((json as JSONArray)[0]) ? {} : ''
+  const newValue = isJSONObject((json as Array<unknown>)[0]) ? {} : ''
   const values = [{ key: '', value: newValue }]
   const operations = insertBefore(json, rowPath, values)
 
@@ -358,7 +356,7 @@ export function onInsertBeforeRow({
 }
 
 export interface OnInsertAfterRowAction {
-  json: JSONValue | undefined
+  json: unknown | undefined
   documentState: DocumentState
   columns: JSONPath[]
   readOnly: boolean
@@ -395,11 +393,11 @@ export function onInsertAfterRow({
 
   const nextRowIndex = rowIndex + 1
   const nextRowPath = [String(nextRowIndex)]
-  const newValue = isJSONObject((json as JSONArray)[0]) ? {} : ''
+  const newValue = isJSONObject((json as Array<unknown>)[0]) ? {} : ''
   const values = [{ key: '', value: newValue }]
 
   const operations =
-    nextRowIndex < (json as JSONArray).length
+    nextRowIndex < (json as Array<unknown>).length
       ? insertBefore(json, nextRowPath, values)
       : append(json, [], values)
 
@@ -417,7 +415,7 @@ export function onInsertAfterRow({
 }
 
 export interface OnRemoveRowAction {
-  json: JSONValue | undefined
+  json: unknown | undefined
   documentState: DocumentState
   columns: JSONPath[]
   readOnly: boolean
@@ -457,7 +455,7 @@ export function onRemoveRow({
 
   onPatch(operations, (patchedJson, patchedState) => {
     const newRowIndex =
-      rowIndex < (patchedJson as JSONArray).length
+      rowIndex < (patchedJson as Array<unknown>).length
         ? rowIndex
         : rowIndex > 0
           ? rowIndex - 1
@@ -486,12 +484,12 @@ export interface OnInsert {
   insertType: InsertType
   selectInside: boolean
   refJsonEditor: HTMLElement
-  json: JSONValue | undefined
+  json: unknown | undefined
   selection: JSONSelection | null
   readOnly: boolean
   parser: JSONParser
   onPatch: OnPatch
-  onReplaceJson: (updatedJson: JSONValue, afterPatch: AfterPatchCallback) => void
+  onReplaceJson: (updatedJson: unknown, afterPatch: AfterPatchCallback) => void
 }
 
 // TODO: write unit tests
@@ -586,12 +584,12 @@ export interface OnInsertCharacter {
   char: string
   selectInside: boolean
   refJsonEditor: HTMLElement
-  json: JSONValue | undefined
+  json: unknown | undefined
   selection: JSONSelection | null
   readOnly: boolean
   parser: JSONParser
   onPatch: OnPatch
-  onReplaceJson: (updatedJson: JSONValue, afterPatch: AfterPatchCallback) => void
+  onReplaceJson: (updatedJson: unknown, afterPatch: AfterPatchCallback) => void
   onSelect: OnJSONSelect
 }
 
@@ -688,12 +686,12 @@ export async function onInsertCharacter({
 interface OnInsertValueWithCharacter {
   char: string
   refJsonEditor: HTMLElement
-  json: JSONValue | undefined
+  json: unknown | undefined
   selection: JSONSelection | null
   readOnly: boolean
   parser: JSONParser
   onPatch: OnPatch
-  onReplaceJson: (updatedJson: JSONValue, afterPatch: AfterPatchCallback) => void
+  onReplaceJson: (updatedJson: unknown, afterPatch: AfterPatchCallback) => void
 }
 
 async function onInsertValueWithCharacter({

--- a/src/lib/logic/documentState.test.ts
+++ b/src/lib/logic/documentState.test.ts
@@ -22,10 +22,7 @@ import {
 import {
   CaretType,
   type DocumentState,
-  type JSONArray,
-  type JSONObject,
   type JSONPointerMap,
-  type JSONValue,
   type VisibleSection
 } from '$lib/types.js'
 import type { JSONPatchDocument } from 'immutable-json-patch'
@@ -372,7 +369,7 @@ describe('documentState', () => {
   })
 
   describe('documentStatePatch', () => {
-    function createJsonAndState(): { json: JSONValue; documentState: DocumentState } {
+    function createJsonAndState(): { json: unknown; documentState: DocumentState } {
       const json = {
         members: [
           { id: 1, name: 'Joe' },
@@ -447,7 +444,7 @@ describe('documentState', () => {
         { op: 'add', path: '/members/1', value: { id: 42, name: 'Julia' } }
       ])
 
-      assert.deepStrictEqual((res.json as JSONObject)?.['members'], [
+      assert.deepStrictEqual((res.json as Record<string, unknown>)?.['members'], [
         { id: 1, name: 'Joe' },
         { id: 42, name: 'Julia' },
         { id: 2, name: 'Sarah' },
@@ -478,7 +475,7 @@ describe('documentState', () => {
         { op: 'add', path: '/members/-', value: { id: 4, name: 'John' } }
       ])
 
-      assert.deepStrictEqual((res.json as JSONObject)['members'], [
+      assert.deepStrictEqual((res.json as Record<string, unknown>)['members'], [
         { id: 1, name: 'Joe' },
         { id: 2, name: 'Sarah' },
         { id: 3, name: 'Mark' },
@@ -671,7 +668,7 @@ describe('documentState', () => {
       const res = documentStatePatch(json, documentState, operations)
 
       // check order of keys
-      assert.deepStrictEqual(Object.keys(res.json as JSONObject), ['a', 'b', 'd'])
+      assert.deepStrictEqual(Object.keys(res.json as Record<string, unknown>), ['a', 'b', 'd'])
 
       // keep expanded state of existing keys
       assert.strictEqual(res.documentState.expandedMap[compileJSONPointer([])], true)
@@ -690,7 +687,11 @@ describe('documentState', () => {
 
       assert.deepStrictEqual(
         res.json,
-        setIn(json, ['group', 'user'], ((json as JSONObject)['members'] as JSONArray)[1])
+        setIn(
+          json,
+          ['group', 'user'],
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[1]
+        )
       )
       assert.deepStrictEqual(res.documentState, {
         ...documentState,
@@ -709,12 +710,12 @@ describe('documentState', () => {
       ])
 
       assert.deepStrictEqual(res.json, {
-        group: (json as JSONObject)['group'],
+        group: (json as Record<string, unknown>)['group'],
         members: [
-          ((json as JSONObject)['members'] as JSONArray)[0],
-          ((json as JSONObject)['group'] as JSONObject)['details'],
-          ((json as JSONObject)['members'] as JSONArray)[1],
-          ((json as JSONObject)['members'] as JSONArray)[2]
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[0],
+          ((json as Record<string, unknown>)['group'] as Record<string, unknown>)['details'],
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[1],
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[2]
         ]
       })
 
@@ -738,7 +739,7 @@ describe('documentState', () => {
       ])
 
       assert.deepStrictEqual(res.json, {
-        members: (json as JSONObject)['members'],
+        members: (json as Record<string, unknown>)['members'],
         group: {
           name: 'Group 1',
           location: 'Block C'
@@ -783,11 +784,11 @@ describe('documentState', () => {
       ])
 
       assert.deepStrictEqual(res.json, {
-        group: (json as JSONObject)['group'],
+        group: (json as Record<string, unknown>)['group'],
         members: [
-          ((json as JSONObject)['members'] as JSONArray)[1],
-          ((json as JSONObject)['members'] as JSONArray)[0],
-          ((json as JSONObject)['members'] as JSONArray)[2]
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[1],
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[0],
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[2]
         ]
       })
 
@@ -816,11 +817,11 @@ describe('documentState', () => {
       ])
 
       assert.deepStrictEqual(res.json, {
-        group: (json as JSONObject)['group'],
+        group: (json as Record<string, unknown>)['group'],
         members: [
-          ((json as JSONObject)['members'] as JSONArray)[1],
-          ((json as JSONObject)['members'] as JSONArray)[0],
-          ((json as JSONObject)['members'] as JSONArray)[2]
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[1],
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[0],
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[2]
         ]
       })
 
@@ -853,12 +854,12 @@ describe('documentState', () => {
           location: 'Block C'
         },
         members: [
-          ((json as JSONObject)['members'] as JSONArray)[0],
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[0],
           {
             description: 'The first group'
           },
-          ((json as JSONObject)['members'] as JSONArray)[1],
-          ((json as JSONObject)['members'] as JSONArray)[2]
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[1],
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[2]
         ]
       })
 
@@ -888,12 +889,12 @@ describe('documentState', () => {
 
       assert.deepStrictEqual(res.json, {
         group: {
-          ...((json as JSONObject)['group'] as JSONObject),
-          user: ((json as JSONObject)['members'] as JSONArray)[1]
+          ...((json as Record<string, unknown>)['group'] as Record<string, unknown>),
+          user: ((json as Record<string, unknown>)['members'] as Array<unknown>)[1]
         },
         members: [
-          ((json as JSONObject)['members'] as JSONArray)[0],
-          ((json as JSONObject)['members'] as JSONArray)[2]
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[0],
+          ((json as Record<string, unknown>)['members'] as Array<unknown>)[2]
         ]
       })
 
@@ -1177,7 +1178,7 @@ describe('documentState', () => {
 /**
  * Helper function to get the visible indices of an Array state
  */
-function getVisibleIndices(json: JSONValue, visibleSections: VisibleSection[]): number[] {
+function getVisibleIndices(json: unknown, visibleSections: VisibleSection[]): number[] {
   const visibleIndices: number[] = []
 
   if (Array.isArray(json)) {

--- a/src/lib/logic/documentState.ts
+++ b/src/lib/logic/documentState.ts
@@ -35,11 +35,9 @@ import {
 import type {
   CaretPosition,
   DocumentState,
-  JSONArray,
   JSONParser,
   JSONPointerMap,
   JSONSelection,
-  JSONValue,
   OnExpand,
   Section,
   VisibleSection
@@ -49,10 +47,10 @@ import { CaretType } from '$lib/types.js'
 import { int } from '../utils/numberUtils.js'
 import { isLargeContent } from '$lib/utils/jsonUtils.js'
 
-type OnCreateSelection = (json: JSONValue, documentState: DocumentState) => JSONSelection
+type OnCreateSelection = (json: unknown, documentState: DocumentState) => JSONSelection
 
 export type CreateDocumentStateProps = {
-  json: JSONValue | undefined
+  json: unknown | undefined
   expand?: OnExpand
   select?: OnCreateSelection
 }
@@ -95,7 +93,7 @@ export function getVisibleSections(
  * Invoke a callback function for every visible item in the array
  */
 export function forEachVisibleIndex(
-  jsonArray: JSONArray,
+  jsonArray: Array<unknown>,
   visibleSections: VisibleSection[],
   callback: (index: number) => void
 ) {
@@ -109,7 +107,7 @@ export function forEachVisibleIndex(
  * The end of the path itself is not expanded
  */
 export function expandPath(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   path: JSONPath
 ): DocumentState {
@@ -152,7 +150,7 @@ export function expandPath(
  * Nodes that are already expanded will be left untouched
  */
 export function expandWithCallback(
-  json: JSONValue | undefined,
+  json: unknown | undefined,
   documentState: DocumentState,
   path: JSONPath,
   expandedCallback: OnExpand
@@ -266,7 +264,7 @@ export function setEnforceString(
  * Expand a section of items in an array
  */
 export function expandSection(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   pointer: JSONPointer,
   section: Section
@@ -300,11 +298,11 @@ export function syncKeys(actualKeys: string[], prevKeys?: string[]): string[] {
  * Apply patch operations to both json and state
  */
 export function documentStatePatch(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   operations: JSONPatchDocument
-): { json: JSONValue; documentState: DocumentState } {
-  const updatedJson: JSONValue = immutableJSONPatch(json, operations)
+): { json: unknown; documentState: DocumentState } {
+  const updatedJson: unknown = immutableJSONPatch(json, operations)
 
   const updatedDocumentState = operations.reduce((updatingState, operation) => {
     if (isJSONPatchAdd(operation)) {
@@ -333,7 +331,7 @@ export function documentStatePatch(
 }
 
 export function documentStateAdd(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   operation: JSONPatchAdd
 ): DocumentState {
@@ -368,7 +366,7 @@ export function documentStateAdd(
 }
 
 export function documentStateRemove(
-  updatedJson: JSONValue,
+  updatedJson: unknown,
   documentState: DocumentState,
   operation: JSONPatchRemove
 ): DocumentState {
@@ -407,7 +405,7 @@ export function documentStateRemove(
 }
 
 export function documentStateReplace(
-  updatedJson: JSONValue,
+  updatedJson: unknown,
   documentState: DocumentState,
   operation: JSONPatchReplace
 ): DocumentState {
@@ -438,7 +436,7 @@ export function documentStateReplace(
 }
 
 export function documentStateMoveOrCopy(
-  updatedJson: JSONValue,
+  updatedJson: unknown,
   documentState: DocumentState,
   operation: JSONPatchCopy | JSONPatchMove
 ): DocumentState {
@@ -593,7 +591,7 @@ export function shiftPath<T>(
 
 // TODO: unit test
 export function cleanupNonExistingPaths<T>(
-  json: JSONValue,
+  json: unknown,
   map: JSONPointerMap<T>
 ): JSONPointerMap<T> {
   const updatedMap: JSONPointerMap<T> = {}
@@ -678,7 +676,7 @@ function mergeAdjacentSections(visibleSections: VisibleSection[]): VisibleSectio
 }
 
 export function getEnforceString(
-  value: JSONValue,
+  value: unknown,
   enforceStringMap: JSONPointerMap<boolean> | undefined,
   pointer: JSONPointer,
   parser: JSONParser
@@ -706,10 +704,10 @@ export function getNextKeys(keys: string[], key: string, includeKey = false): st
  * Get all paths which are visible and rendered
  */
 // TODO: create memoized version of getVisiblePaths which remembers just the previous result if json and state are the same
-export function getVisiblePaths(json: JSONValue, documentState: DocumentState): JSONPath[] {
+export function getVisiblePaths(json: unknown, documentState: DocumentState): JSONPath[] {
   const paths: JSONPath[] = []
 
-  function _recurse(value: JSONValue, path: JSONPath) {
+  function _recurse(value: unknown, path: JSONPath) {
     paths.push(path)
     const pointer = compileJSONPointer(path)
 
@@ -740,13 +738,13 @@ export function getVisiblePaths(json: JSONValue, documentState: DocumentState): 
  */
 // TODO: create memoized version of getVisibleCaretPositions which remembers just the previous result if json and state are the same
 export function getVisibleCaretPositions(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   includeInside = true
 ): CaretPosition[] {
   const paths: CaretPosition[] = []
 
-  function _recurse(value: JSONValue, path: JSONPath) {
+  function _recurse(value: unknown, path: JSONPath) {
     paths.push({ path, type: CaretType.value })
 
     const pointer = compileJSONPointer(path)
@@ -796,7 +794,7 @@ export function getVisibleCaretPositions(
  */
 // TODO: write tests for getPreviousVisiblePath
 export function getPreviousVisiblePath(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   path: JSONPath
 ): JSONPath | null {
@@ -818,7 +816,7 @@ export function getPreviousVisiblePath(
  */
 // TODO: write tests for getNextVisiblePath
 export function getNextVisiblePath(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   path: JSONPath
 ): JSONPath | null {
@@ -839,11 +837,11 @@ export function getNextVisiblePath(
  */
 // TODO: write unit test
 export function expandRecursive(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   path: JSONPath
 ): DocumentState {
-  const expandContents: JSONValue | undefined = getIn(json, path)
+  const expandContents: unknown | undefined = getIn(json, path)
   if (expandContents === undefined) {
     return documentState
   }
@@ -865,6 +863,6 @@ export function expandAll(): boolean {
 }
 
 // TODO: write unit test
-export function getDefaultExpand(json: JSONValue): OnExpand {
+export function getDefaultExpand(json: unknown): OnExpand {
   return isLargeContent({ json }, MAX_DOCUMENT_SIZE_EXPAND_ALL) ? expandMinimal : expandAll
 }

--- a/src/lib/logic/dragging.ts
+++ b/src/lib/logic/dragging.ts
@@ -8,13 +8,12 @@ import type {
   DragInsideAction,
   DragInsideProps,
   JSONSelection,
-  JSONValue,
   MultiSelection,
   RenderedItem
 } from '$lib/types'
 
 export interface MoveSelectionProps {
-  json: JSONValue
+  json: unknown
   documentState: DocumentState
   deltaY: number
   items: RenderedItem[]
@@ -137,7 +136,7 @@ function findSwapPathDown({
 
 interface UpdatedArraySelectionProps {
   items: RenderedItem[]
-  json: JSONValue
+  json: unknown
   selection: JSONSelection
   offset: number
 }

--- a/src/lib/logic/operations.ts
+++ b/src/lib/logic/operations.ts
@@ -37,14 +37,7 @@ import {
   isValueSelection,
   pathStartsWith
 } from './selection.js'
-import type {
-  ClipboardValues,
-  DragInsideAction,
-  JSONObject,
-  JSONParser,
-  JSONSelection,
-  JSONValue
-} from '$lib/types'
+import type { ClipboardValues, DragInsideAction, JSONParser, JSONSelection } from '$lib/types'
 import { int } from '../utils/numberUtils.js'
 
 /**
@@ -56,7 +49,7 @@ import { int } from '../utils/numberUtils.js'
  */
 // TODO: write tests
 export function insertBefore(
-  json: JSONValue,
+  json: unknown,
   path: JSONPath,
   values: ClipboardValues
 ): JSONPatchDocument {
@@ -105,11 +98,7 @@ export function insertBefore(
  * a unique property name for the inserted node in case of duplicating
  * and object property
  */
-export function append(
-  json: JSONValue,
-  path: JSONPath,
-  values: ClipboardValues
-): JSONPatchDocument {
+export function append(json: unknown, path: JSONPath, values: ClipboardValues): JSONPatchDocument {
   const parent = getIn(json, path)
 
   if (Array.isArray(parent)) {
@@ -122,7 +111,7 @@ export function append(
   } else {
     // 'object'
     return values.map((entry) => {
-      const newProp = findUniqueName(entry.key, Object.keys(parent as JSONObject))
+      const newProp = findUniqueName(entry.key, Object.keys(parent as Record<string, unknown>))
       return {
         op: 'add',
         path: compileJSONPointer(path.concat(newProp)),
@@ -167,7 +156,7 @@ export function rename(
  * and object property
  */
 export function replace(
-  json: JSONValue,
+  json: unknown,
   paths: JSONPath[],
   values: ClipboardValues
 ): JSONPatchDocument {
@@ -236,7 +225,7 @@ export function replace(
  * a unique property name for the duplicated node in case of duplicating
  * and object property
  */
-export function duplicate(json: JSONValue, paths: JSONPath[]): JSONPatchDocument {
+export function duplicate(json: unknown, paths: JSONPath[]): JSONPatchDocument {
   // FIXME: here we assume paths is sorted correctly, that's a dangerous assumption
   const lastPath = last(paths)
 
@@ -295,7 +284,7 @@ export function duplicate(json: JSONValue, paths: JSONPath[]): JSONPatchDocument
  * Create a JSONPatch for an extract action.
  */
 // TODO: write unit tests
-export function extract(json: JSONValue, selection: JSONSelection): JSONPatchDocument {
+export function extract(json: unknown, selection: JSONSelection): JSONPatchDocument {
   if (isValueSelection(selection)) {
     return [
       {
@@ -325,10 +314,10 @@ export function extract(json: JSONValue, selection: JSONSelection): JSONPatchDoc
       ]
     } else if (isJSONObject(parent)) {
       // object
-      const value: JSONObject = {}
+      const value: Record<string, unknown> = {}
       getSelectionPaths(json, selection).forEach((path) => {
         const key = String(last(path))
-        value[key] = parent[key] as JSONValue
+        value[key] = parent[key]
       })
 
       return [
@@ -349,7 +338,7 @@ export function extract(json: JSONValue, selection: JSONSelection): JSONPatchDoc
 
 // TODO: write unit tests
 export function insert(
-  json: JSONValue,
+  json: unknown,
   selection: JSONSelection | null,
   clipboardText: string,
   parser: JSONParser
@@ -359,7 +348,7 @@ export function insert(
     const clipboard = parseAndRepairOrUndefined(clipboardText, parser)
     const parentPath = initial(selection.path)
     const parent = getIn(json, parentPath)
-    const keys = Object.keys(parent as JSONObject)
+    const keys = Object.keys(parent as Record<string, unknown>)
     const oldKey = last(selection.path) as string
     const newKey = typeof clipboard === 'string' ? clipboard : clipboardText
 
@@ -376,9 +365,7 @@ export function insert(
         {
           op: 'replace',
           path: compileJSONPointer(getFocusPath(selection)),
-          value: parsePartialJson(clipboardText, (text) =>
-            parseAndRepair(text, parser)
-          ) as JSONValue
+          value: parsePartialJson(clipboardText, (text) => parseAndRepair(text, parser))
         }
       ]
     } catch (err) {
@@ -457,7 +444,7 @@ export function insert(
 }
 
 export function moveInsideParent(
-  json: JSONValue,
+  json: unknown,
   selection: JSONSelection | null,
   dragInsideAction: DragInsideAction
 ): JSONPatchDocument {
@@ -541,7 +528,7 @@ export function moveInsideParent(
 }
 
 export function createNewValue(
-  json: JSONValue | undefined,
+  json: unknown | undefined,
   selection: JSONSelection | null,
   valueType: 'object' | 'array' | 'structure' | 'value'
 ) {
@@ -632,7 +619,7 @@ export function clipboardToValues(clipboardText: string, parser: JSONParser): Cl
     (textIsObject && isObject(clipboardRepaired)) ||
     (textIsArray && Array.isArray(clipboardRepaired))
   ) {
-    return [{ key: 'New item', value: clipboardRepaired as JSONValue }]
+    return [{ key: 'New item', value: clipboardRepaired }]
   }
 
   if (Array.isArray(clipboardRepaired)) {
@@ -643,24 +630,24 @@ export function clipboardToValues(clipboardText: string, parser: JSONParser): Cl
 
   if (isObject(clipboardRepaired)) {
     return Object.keys(clipboardRepaired).map((key) => {
-      return { key, value: clipboardRepaired[key] as JSONValue }
+      return { key, value: clipboardRepaired[key] }
     })
   }
 
   // regular value
-  return [{ key: 'New item', value: clipboardRepaired as JSONValue }]
+  return [{ key: 'New item', value: clipboardRepaired }]
 }
 
 // TODO: write unit tests
 export function createRemoveOperations(
-  json: JSONValue,
+  json: unknown,
   selection: JSONSelection
 ): { newSelection: JSONSelection | null; operations: JSONPatchDocument } {
   if (isKeySelection(selection)) {
     // FIXME: DOESN'T work yet
     const parentPath = initial(selection.path)
     const parent = getIn(json, parentPath)
-    const keys = Object.keys(parent as JSONObject)
+    const keys = Object.keys(parent as Record<string, unknown>)
     const oldKey = last(selection.path) as string
     const newKey = ''
 
@@ -731,7 +718,7 @@ export function createRemoveOperations(
 }
 
 export function revertJSONPatchWithMoveOperations(
-  json: JSONValue,
+  json: unknown,
   operations: JSONPatchDocument
 ): JSONPatchDocument {
   return revertJSONPatch(json, operations, {
@@ -739,20 +726,14 @@ export function revertJSONPatchWithMoveOperations(
       if (isJSONPatchRemove(operation)) {
         const path = parseJSONPointer(operation.path)
         return {
-          revertOperations: [
-            ...revertOperations,
-            ...createRevertMoveOperations(json as JSONValue, path)
-          ]
+          revertOperations: [...revertOperations, ...createRevertMoveOperations(json, path)]
         }
       }
 
       if (isJSONPatchMove(operation)) {
         const from = parseJSONPointer(operation.from)
         return {
-          revertOperations: [
-            ...revertOperations,
-            ...createRevertMoveOperations(json as JSONValue, from)
-          ]
+          revertOperations: [...revertOperations, ...createRevertMoveOperations(json, from)]
         }
       }
 
@@ -761,7 +742,7 @@ export function revertJSONPatchWithMoveOperations(
   })
 }
 
-function createRevertMoveOperations(json: JSONValue, path: JSONPath): JSONPatchOperation[] {
+function createRevertMoveOperations(json: unknown, path: JSONPath): JSONPatchOperation[] {
   const parentPath = initial(path)
   const afterKey = last(path) as string
   const parent = getIn(json, parentPath)
@@ -779,7 +760,7 @@ function createRevertMoveOperations(json: JSONValue, path: JSONPath): JSONPatchO
 /**
  * Add operations to create parent objects when missing before replacing a nested value
  */
-export function createNestedValueOperations(operations: JSONPatchOperation[], json: JSONValue) {
+export function createNestedValueOperations(operations: JSONPatchOperation[], json: unknown) {
   return operations.flatMap((operation) => {
     if (isJSONPatchReplace(operation)) {
       const path = parseJSONPointer(operation.path)

--- a/src/lib/logic/operations.ts
+++ b/src/lib/logic/operations.ts
@@ -531,7 +531,7 @@ export function createNewValue(
   json: unknown | undefined,
   selection: JSONSelection | null,
   valueType: 'object' | 'array' | 'structure' | 'value'
-) {
+): unknown {
   if (valueType === 'object') {
     return {}
   }

--- a/src/lib/logic/search.ts
+++ b/src/lib/logic/search.ts
@@ -13,11 +13,9 @@ import { stringConvert } from '../utils/typeUtils.js'
 import type {
   DocumentState,
   ExtendedSearchResultItem,
-  JSONObject,
   JSONParser,
   JSONPointerMap,
   JSONSelection,
-  JSONValue,
   SearchResult,
   SearchResultItem
 } from '$lib/types'
@@ -26,7 +24,7 @@ import { SearchField } from '$lib/types.js'
 // TODO: comment
 // TODO: unit test
 export function updateSearchResult(
-  json: JSONValue,
+  json: unknown,
   newResultItems: SearchResultItem[],
   previousResult: SearchResult | undefined
 ): SearchResult {
@@ -109,7 +107,7 @@ export function searchPrevious(searchResult: SearchResult): SearchResult {
 // TODO: comment
 export function search(
   searchText: string,
-  json: JSONValue,
+  json: unknown,
   maxResults = Infinity
 ): SearchResultItem[] {
   const results: SearchResultItem[] = []
@@ -121,7 +119,7 @@ export function search(
     }
   }
 
-  function searchRecursive(searchTextLowerCase: string, value: JSONValue) {
+  function searchRecursive(searchTextLowerCase: string, value: unknown) {
     if (isJSONArray(value)) {
       const level = path.length
       path.push('0')
@@ -236,7 +234,7 @@ export function replaceAllText(
 }
 
 export function createSearchAndReplaceOperations(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   replacementText: string,
   searchResultItem: SearchResultItem,
@@ -249,7 +247,7 @@ export function createSearchAndReplaceOperations(
     const parentPath = initial(path)
     const parent = getIn(json, parentPath)
     const oldKey = last(path) as string
-    const keys = Object.keys(parent as JSONObject)
+    const keys = Object.keys(parent as Record<string, unknown>)
     const newKey = replaceText(oldKey, replacementText, start, end)
 
     const operations = rename(parentPath, keys, oldKey, newKey)
@@ -261,7 +259,7 @@ export function createSearchAndReplaceOperations(
     }
   } else if (field === SearchField.value) {
     // replace a value
-    const currentValue: JSONValue | undefined = getIn(json, path)
+    const currentValue: unknown | undefined = getIn(json, path)
     if (currentValue === undefined) {
       throw new Error(`Cannot replace: path not found ${compileJSONPointer(path)}`)
     }
@@ -281,7 +279,7 @@ export function createSearchAndReplaceOperations(
       {
         op: 'replace',
         path: compileJSONPointer(path),
-        value: enforceString ? value : (stringConvert(value, parser) as JSONValue)
+        value: enforceString ? value : stringConvert(value, parser)
       }
     ]
 
@@ -297,7 +295,7 @@ export function createSearchAndReplaceOperations(
 }
 
 export function createSearchAndReplaceAllOperations(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   searchText: string,
   replacementText: string,
@@ -358,7 +356,7 @@ export function createSearchAndReplaceAllOperations(
       const parentPath = initial(path)
       const parent = getIn(json, parentPath)
       const oldKey = last(path) as string
-      const keys = Object.keys(parent as JSONObject)
+      const keys = Object.keys(parent as Record<string, unknown>)
       const newKey = replaceAllText(oldKey, replacementText, items)
 
       const operations = rename(parentPath, keys, oldKey, newKey)
@@ -367,7 +365,7 @@ export function createSearchAndReplaceAllOperations(
       lastNewSelection = createSelectionFromOperations(json, operations)
     } else if (field === SearchField.value) {
       // replace a value
-      const currentValue: JSONValue | undefined = getIn(json, path)
+      const currentValue: unknown | undefined = getIn(json, path)
       if (currentValue === undefined) {
         throw new Error(`Cannot replace: path not found ${compileJSONPointer(path)}`)
       }
@@ -388,7 +386,7 @@ export function createSearchAndReplaceAllOperations(
         {
           op: 'replace',
           path: compileJSONPointer(path),
-          value: enforceString ? value : (stringConvert(value, parser) as JSONValue)
+          value: enforceString ? value : stringConvert(value, parser)
         }
       ]
       allOperations = allOperations.concat(operations)

--- a/src/lib/logic/selection.test.ts
+++ b/src/lib/logic/selection.test.ts
@@ -20,12 +20,7 @@ import {
   pathInSelection
 } from './selection.js'
 import { createDocumentState } from './documentState.js'
-import {
-  type DocumentState,
-  type JSONSelection,
-  type JSONValue,
-  SelectionType
-} from '$lib/types.js'
+import { type DocumentState, type JSONSelection, SelectionType } from '$lib/types.js'
 
 describe('selection', () => {
   const json = {
@@ -636,7 +631,7 @@ describe('selection', () => {
   })
 
   test('getInitialSelection', () => {
-    function getInitialSelectionWithState(json: JSONValue) {
+    function getInitialSelectionWithState(json: unknown) {
       const documentState = createDocumentState({ json, expand: (path) => path.length <= 1 })
       return getInitialSelection(json, documentState)
     }

--- a/src/lib/logic/selection.ts
+++ b/src/lib/logic/selection.ts
@@ -658,13 +658,13 @@ export function selectionToPartialJson(
 
   if (isValueSelection(selection)) {
     const value = getIn(json, selection.path)
-    return typeof value === 'string' ? value : parser.stringify(value, null, indentation) // TODO: customizable indentation?
+    return typeof value === 'string' ? value : parser.stringify(value, null, indentation) ?? null // TODO: customizable indentation?
   }
 
   if (isMultiSelection(selection)) {
     if (isEmpty(selection.focusPath)) {
       // root object -> does not have a parent key/index
-      return parser.stringify(json, null, indentation)
+      return parser.stringify(json, null, indentation) ?? null
     }
 
     const parentPath = getParentPath(selection)
@@ -673,7 +673,7 @@ export function selectionToPartialJson(
       if (isMultiSelectionWithOneItem(selection)) {
         // do not suffix a single selected array item with a comma
         const item = getIn(json, selection.focusPath)
-        return parser.stringify(item, null, indentation)
+        return parser.stringify(item, null, indentation) ?? null
       } else {
         return getSelectionPaths(json, selection)
           .map((path) => {

--- a/src/lib/logic/selection.ts
+++ b/src/lib/logic/selection.ts
@@ -26,7 +26,6 @@ import type {
   JSONEditorSelection,
   JSONParser,
   JSONSelection,
-  JSONValue,
   KeySelection,
   MultiSelection,
   TextSelection,
@@ -77,7 +76,7 @@ export function isTextSelection(selection: JSONEditorSelection | null): selectio
  * Expand a selection start and end into an array containing all paths
  * between (and including) start and end
  */
-export function getSelectionPaths(json: JSONValue, selection: JSONSelection): JSONPath[] {
+export function getSelectionPaths(json: unknown, selection: JSONSelection): JSONPath[] {
   const paths: JSONPath[] = []
 
   iterateOverSelection(json, selection, (path) => {
@@ -98,7 +97,7 @@ export function getSelectionPaths(json: JSONValue, selection: JSONSelection): JS
  * canceled and the value returned by the callback is returned by iterateOverSelection.
  */
 export function iterateOverSelection<T>(
-  json: JSONValue | undefined,
+  json: unknown | undefined,
   selection: JSONSelection | null,
   callback: (path: JSONPath) => void | undefined | T
 ): void | undefined | T {
@@ -174,7 +173,7 @@ export function getParentPath(selection: JSONSelection): JSONPath {
   }
 }
 
-export function getStartPath(json: JSONValue, selection: JSONSelection): JSONPath {
+export function getStartPath(json: unknown, selection: JSONSelection): JSONPath {
   if (!isMultiSelection(selection)) {
     return selection.path
   }
@@ -185,7 +184,7 @@ export function getStartPath(json: JSONValue, selection: JSONSelection): JSONPat
   return focusIndex < anchorIndex ? selection.focusPath : selection.anchorPath
 }
 
-export function getEndPath(json: JSONValue, selection: JSONSelection): JSONPath {
+export function getEndPath(json: unknown, selection: JSONSelection): JSONPath {
   if (!isMultiSelection(selection)) {
     return selection.path
   }
@@ -205,7 +204,7 @@ export function isSelectionInsidePath(selection: JSONSelection, path: JSONPath):
 }
 
 export function getSelectionUp(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   keepAnchorPath = false
 ): JSONSelection | null {
@@ -266,7 +265,7 @@ export function getSelectionUp(
 }
 
 export function getSelectionDown(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   keepAnchorPath = false
 ): JSONSelection | null {
@@ -344,7 +343,7 @@ export function getSelectionDown(
  * Only applicable for ValueSelection
  */
 export function getSelectionNextInside(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   path: JSONPath
 ): JSONSelection | null {
@@ -352,7 +351,7 @@ export function getSelectionNextInside(
   const parentPath = initial(path)
   const childPath = [last(path) as string]
 
-  const parent: JSONValue | undefined = getIn(json, parentPath)
+  const parent: unknown | undefined = getIn(json, parentPath)
   const nextPathInside = parent ? getNextVisiblePath(parent, documentState, childPath) : undefined
 
   if (nextPathInside) {
@@ -367,7 +366,7 @@ export function getSelectionNextInside(
  */
 // TODO: unit test
 export function findCaretAndSiblings(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   includeInside: boolean
 ): { next: CaretPosition | null; caret: CaretPosition | null; previous: CaretPosition | null } {
@@ -396,7 +395,7 @@ export function findCaretAndSiblings(
 }
 
 export function getSelectionLeft(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   keepAnchorPath = false,
   includeInside = true
@@ -435,7 +434,7 @@ export function getSelectionLeft(
 }
 
 export function getSelectionRight(
-  json: JSONValue,
+  json: unknown,
   documentState: DocumentState,
   keepAnchorPath = false,
   includeInside = true
@@ -469,7 +468,7 @@ export function getSelectionRight(
 /**
  * Get a proper initial selection based on what is visible
  */
-export function getInitialSelection(json: JSONValue, documentState: DocumentState): JSONSelection {
+export function getInitialSelection(json: unknown, documentState: DocumentState): JSONSelection {
   const visiblePaths = getVisiblePaths(json, documentState)
 
   // find the first, deepest nested entry (normally a value, not an Object/Array)
@@ -488,7 +487,7 @@ export function getInitialSelection(json: JSONValue, documentState: DocumentStat
 }
 
 export function createSelectionFromOperations(
-  json: JSONValue,
+  json: unknown,
   operations: JSONPatchDocument
 ): JSONSelection | null {
   if (operations.length === 1) {
@@ -563,7 +562,7 @@ export function singleItemSelected(selection: JSONSelection | null): boolean {
   )
 }
 
-export function findRootPath(json: JSONValue, selection: JSONSelection): JSONPath {
+export function findRootPath(json: unknown, selection: JSONSelection): JSONPath {
   return singleItemSelected(selection) && isObjectOrArray(getIn(json, getFocusPath(selection)))
     ? getFocusPath(selection)
     : initial(getFocusPath(selection)) // the parent path of the paths
@@ -648,7 +647,7 @@ export function createMultiSelection(anchorPath: JSONPath, focusPath: JSONPath):
  * clipboard for example.
  */
 export function selectionToPartialJson(
-  json: JSONValue,
+  json: unknown,
   selection: JSONSelection | null,
   indentation: number | string | undefined,
   parser: JSONParser
@@ -758,7 +757,7 @@ export function fromCaretPosition(caretPosition: CaretPosition): JSONSelection {
 
 // TODO: unit test
 export function fromSelectionType(
-  json: JSONValue,
+  json: unknown,
   selectionType: SelectionType,
   path: JSONPath
 ): JSONSelection {
@@ -778,7 +777,7 @@ export function fromSelectionType(
 }
 
 export function selectionIfOverlapping(
-  json: JSONValue | undefined,
+  json: unknown | undefined,
   selection: JSONSelection | null,
   path: JSONPath
 ): JSONSelection | null {
@@ -799,7 +798,7 @@ export function selectionIfOverlapping(
 }
 
 export function pathInSelection(
-  json: JSONValue | undefined,
+  json: unknown | undefined,
   selection: JSONSelection | null,
   path: JSONPath
 ): boolean {
@@ -833,7 +832,7 @@ export function pathInSelection(
   return false
 }
 
-function getChildIndex(json: JSONValue, selection: MultiSelection, path: JSONPath): number {
+function getChildIndex(json: unknown, selection: MultiSelection, path: JSONPath): number {
   const parentPath = initial(selection.focusPath)
   if (!pathStartsWith(path, parentPath) || path.length <= parentPath.length) {
     return -1

--- a/src/lib/logic/sort.ts
+++ b/src/lib/logic/sort.ts
@@ -14,7 +14,6 @@ import { first, initial, isEmpty, isEqual, last } from 'lodash-es'
 import naturalCompare from 'natural-compare-lite'
 import { int } from '../utils/numberUtils.js'
 import { isObject } from '../utils/typeUtils.js'
-import type { JSONArray, JSONValue } from '$lib/types.js'
 
 export function caseInsensitiveNaturalCompare(a: unknown, b: unknown) {
   const aLower = typeof a === 'string' ? a.toLowerCase() : a
@@ -34,7 +33,7 @@ export function caseInsensitiveNaturalCompare(a: unknown, b: unknown) {
  *                       to get the array sorted.
  */
 export function sortJson(
-  json: JSONValue,
+  json: unknown,
   rootPath: JSONPath = [],
   itemPath: JSONPath = [],
   direction: 1 | -1 = 1
@@ -64,12 +63,12 @@ export function sortJson(
  *                       to get the array sorted.
  */
 export function sortObjectKeys(
-  json: JSONValue,
+  json: unknown,
   rootPath: JSONPath = [],
   direction: 1 | -1 = 1
 ): JSONPatchDocument {
   const object = getIn(json, rootPath)
-  const keys = Object.keys(object as unknown as Record<string, JSONValue>)
+  const keys = Object.keys(object as unknown as Record<string, unknown>)
   const sortedKeys = keys.slice()
 
   sortedKeys.sort((keyA, keyB) => {
@@ -102,7 +101,7 @@ export function sortObjectKeys(
  *                           to get the array sorted.
  */
 export function sortArray(
-  json: JSONValue,
+  json: unknown,
   rootPath: JSONPath = [],
   propertyPath: JSONPath = [],
   direction: 1 | -1 = 1
@@ -110,7 +109,7 @@ export function sortArray(
   const comparator = createObjectComparator(propertyPath, direction)
 
   // TODO: make the mechanism to sort configurable? Like use sortOperationsMove and sortOperationsMoveAdvanced
-  const array: JSONArray = getIn(json, rootPath) as JSONArray
+  const array = getIn(json, rootPath) as Array<unknown>
   return [
     {
       op: 'replace',
@@ -124,7 +123,7 @@ export function sortArray(
  * Create a comparator function to compare nested properties in an array
  */
 function createObjectComparator(propertyPath: JSONPath, direction: 1 | -1) {
-  return function comparator(a: JSONValue, b: JSONValue) {
+  return function comparator(a: unknown, b: unknown) {
     const valueA = getIn(a, propertyPath)
     const valueB = getIn(b, propertyPath)
 
@@ -262,7 +261,7 @@ export function sortOperationsMoveAdvanced<T>(
  * array.
  */
 // TODO: write unit tests
-export function fastPatchSort(json: JSONValue, operations: JSONPatchDocument): JSONValue {
+export function fastPatchSort(json: unknown, operations: JSONPatchDocument): unknown {
   if (isEmpty(operations)) {
     // nothing to do :)
     return json

--- a/src/lib/logic/table.test.ts
+++ b/src/lib/logic/table.test.ts
@@ -19,11 +19,11 @@ import {
 import { deepStrictEqual } from 'assert'
 import type { JSONPath } from 'immutable-json-patch'
 import { createValueSelection } from './selection.js'
-import type { JSONArray, JSONValue, SortedColumn, ValidationError } from '$lib/types.js'
+import type { SortedColumn, ValidationError } from '$lib/types.js'
 import { SortDirection, ValidationSeverity } from '$lib/types.js'
 
 describe('table', () => {
-  const json: JSONValue = [
+  const json: unknown[] = [
     { name: 'Joe', address: { city: 'New York', street: 'Main street' }, scores: [1, 2, 3] },
     {
       name: 'Sarah',
@@ -58,13 +58,13 @@ describe('table', () => {
   })
 
   test('should extract table columns from non-homogeneous data', () => {
-    const data: JSONArray = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5, name: 'Sarah' }]
+    const data = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5, name: 'Sarah' }]
 
     expect(getColumns(data, true, 2)).toEqual([['id'], ['name']])
   })
 
   test('should extract table columns from conflicting data structures', () => {
-    const data: JSONArray = [{ item: 1 }, { item: { id: 1, name: 'Sarah' } }]
+    const data = [{ item: 1 }, { item: { id: 1, name: 'Sarah' } }]
 
     expect(getColumns(data, true)).toEqual([['item'], ['item', 'id'], ['item', 'name']])
   })
@@ -82,7 +82,7 @@ describe('table', () => {
   })
 
   test('should return an empty array on non-array input', () => {
-    deepStrictEqual(getColumns({} as JSONArray, false), [])
+    deepStrictEqual(getColumns({} as unknown[], false), [])
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/src/lib/logic/table.ts
+++ b/src/lib/logic/table.ts
@@ -8,9 +8,7 @@ import {
 import { groupBy, isEmpty, isEqual, mapValues, partition } from 'lodash-es'
 import type {
   DocumentState,
-  JSONArray,
   JSONSelection,
-  JSONValue,
   SortedColumn,
   TableCellIndex,
   ValidationError
@@ -30,7 +28,7 @@ type NestedObject = Record<string, NestedObject>
 const endOfPath = Symbol('path')
 
 export function getColumns(
-  array: JSONArray,
+  array: Array<unknown>,
   flatten: boolean,
   maxSampleCount = Infinity
 ): JSONPath[] {
@@ -121,14 +119,14 @@ export function maintainColumnOrder(
   return [...orderedColumns].map(parseJSONPointer)
 }
 
-export function getShallowKeys(value: JSONValue): JSONPath[] {
+export function getShallowKeys(value: unknown): JSONPath[] {
   return isJSONObject(value) ? Object.keys(value).map((key) => [key]) : [[]]
 }
 
-export function getRecursiveKeys(value: JSONValue): JSONPath[] {
+export function getRecursiveKeys(value: unknown): JSONPath[] {
   const paths: JSONPath[] = []
 
-  function recurse(value: JSONValue, path: JSONPath) {
+  function recurse(value: unknown, path: JSONPath) {
     if (isJSONObject(value)) {
       Object.keys(value).forEach((key) => {
         recurse(value[key], path.concat(key))
@@ -151,14 +149,14 @@ export interface VisibleSection {
   visibleHeight: number
   endHeight: number
   averageItemHeight: number
-  visibleItems: JSONArray
+  visibleItems: Array<unknown>
 }
 
 // TODO: write unit tests
 export function calculateVisibleSection(
   scrollTop: number,
   viewPortHeight: number,
-  json: JSONValue | undefined,
+  json: unknown | undefined,
   itemHeights: Record<number, number>,
   defaultItemHeight: number,
   margin = 80
@@ -212,7 +210,7 @@ export function calculateVisibleSection(
 export function calculateVisibleSectionApprox(
   scrollTop: number,
   viewPortHeight: number,
-  json: JSONValue | undefined,
+  json: unknown | undefined,
   defaultItemHeight: number
 ): VisibleSection {
   const itemCount = isJSONArray(json) ? json.length : 0
@@ -283,13 +281,13 @@ export function selectPreviousRow(columns: JSONPath[], selection: JSONSelection)
 }
 
 export function selectNextRow(
-  json: JSONValue,
+  json: unknown,
   columns: JSONPath[],
   selection: JSONSelection
 ): JSONSelection {
   const { rowIndex, columnIndex } = toTableCellPosition(getFocusPath(selection), columns)
 
-  if (rowIndex < (json as JSONArray).length - 1) {
+  if (rowIndex < (json as Array<unknown>).length - 1) {
     const nextPosition = { rowIndex: rowIndex + 1, columnIndex }
     const nextPath = fromTableCellPosition(nextPosition, columns)
     return createValueSelection(nextPath, false)
@@ -486,10 +484,10 @@ export function operationAffectsSortedColumn(
 /**
  * Find nested arrays inside a JSON object
  */
-export function findNestedArrays(json: JSONValue, maxLevel = 2): JSONPath[] {
+export function findNestedArrays(json: unknown, maxLevel = 2): JSONPath[] {
   const props: JSONPath[] = []
 
-  function recurse(value: JSONValue, path: JSONPath) {
+  function recurse(value: unknown, path: JSONPath) {
     if (isJSONObject(value) && path.length < maxLevel) {
       Object.keys(value).forEach((key) => {
         recurse(value[key], path.concat(key))

--- a/src/lib/logic/validation.test.ts
+++ b/src/lib/logic/validation.test.ts
@@ -1,12 +1,12 @@
 import { test, describe } from 'vitest'
 import { deepStrictEqual } from 'assert'
 import { mapValidationErrors, validateJSON, validateText } from './validation.js'
-import type { JSONParser, ValidationError } from '$lib/types'
+import type { ValidationError } from '$lib/types'
 import { ValidationSeverity } from '$lib/types.js'
 import { stringify, parse, isLosslessNumber } from 'lossless-json'
 import { LosslessNumber } from 'lossless-json'
 
-const LosslessJSONParser = { parse, stringify } as JSONParser
+const LosslessJSONParser = { parse, stringify }
 
 describe('validation', () => {
   test('should create a map from a list with validation errors', () => {

--- a/src/lib/logic/validation.test.ts
+++ b/src/lib/logic/validation.test.ts
@@ -1,7 +1,7 @@
 import { test, describe } from 'vitest'
 import { deepStrictEqual } from 'assert'
 import { mapValidationErrors, validateJSON, validateText } from './validation.js'
-import type { JSONParser, JSONValue, ValidationError } from '$lib/types'
+import type { JSONParser, ValidationError } from '$lib/types'
 import { ValidationSeverity } from '$lib/types.js'
 import { stringify, parse, isLosslessNumber } from 'lossless-json'
 import { LosslessNumber } from 'lossless-json'
@@ -64,7 +64,7 @@ describe('validation', () => {
       severity: ValidationSeverity.warning
     }
 
-    function myValidator(json: JSONValue): ValidationError[] {
+    function myValidator(json: unknown): ValidationError[] {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       if (!json || typeof json.count !== 'number' || json.count <= 0) {
@@ -74,7 +74,7 @@ describe('validation', () => {
       return []
     }
 
-    function myLosslessValidator(json: JSONValue): ValidationError[] {
+    function myLosslessValidator(json: unknown): ValidationError[] {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       if (!json || !isLosslessNumber(json.count) || json.count <= 0) {
@@ -84,10 +84,10 @@ describe('validation', () => {
       return []
     }
 
-    const validJson = { count: 42 } as JSONValue
-    const invalidJson = { foo: 42 } as JSONValue
-    const validLosslessJson = { count: new LosslessNumber('42') } as unknown as JSONValue
-    const invalidLosslessJson = { foo: new LosslessNumber('42') } as unknown as JSONValue
+    const validJson = { count: 42 }
+    const invalidJson = { foo: 42 }
+    const validLosslessJson = { count: new LosslessNumber('42') }
+    const invalidLosslessJson = { foo: new LosslessNumber('42') }
 
     test('should validateJSON with native parser and valid JSON', () => {
       deepStrictEqual(validateJSON(validJson, myValidator, JSON, JSON), [])
@@ -117,7 +117,7 @@ describe('validation', () => {
     test('should validateJSON with two lossless parsers and valid lossless JSON', () => {
       deepStrictEqual(
         validateJSON(
-          validLosslessJson as unknown as JSONValue,
+          validLosslessJson,
           myLosslessValidator,
           LosslessJSONParser,
           LosslessJSONParser
@@ -140,7 +140,7 @@ describe('validation', () => {
       severity: ValidationSeverity.warning
     }
 
-    function myValidator(json: JSONValue): ValidationError[] {
+    function myValidator(json: unknown): ValidationError[] {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       if (!json || typeof json.count !== 'number' || json.count <= 0) {
@@ -150,7 +150,7 @@ describe('validation', () => {
       return []
     }
 
-    function myLosslessValidator(json: JSONValue): ValidationError[] {
+    function myLosslessValidator(json: unknown): ValidationError[] {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       if (!json || !isLosslessNumber(json.count) || json.count <= 0) {

--- a/src/lib/logic/validation.ts
+++ b/src/lib/logic/validation.ts
@@ -3,7 +3,6 @@ import type {
   ContentErrors,
   JSONParser,
   JSONPointerMap,
-  JSONValue,
   NestedValidationError,
   ValidationError,
   Validator
@@ -57,7 +56,7 @@ export function mapValidationErrors(
 }
 
 export function validateJSON(
-  json: JSONValue,
+  json: unknown,
   validator: Validator | null,
   parser: JSONParser,
   validationParser: JSONParser

--- a/src/lib/logic/validation.ts
+++ b/src/lib/logic/validation.ts
@@ -70,7 +70,8 @@ export function validateJSON(
   if (parser !== validationParser) {
     // if needed, convert for example Lossless JSON to native JSON
     // (like replace bigint or LosslessNumber into regular numbers)
-    const convertedJSON = validationParser.parse(parser.stringify(json))
+    const text = parser.stringify(json)
+    const convertedJSON = text !== undefined ? validationParser.parse(text) : undefined
     return validator(convertedJSON)
   } else {
     return validator(json)

--- a/src/lib/plugins/query/javascriptQueryLanguage.test.ts
+++ b/src/lib/plugins/query/javascriptQueryLanguage.test.ts
@@ -3,7 +3,6 @@ import assert from 'assert'
 import { javascriptQueryLanguage } from './javascriptQueryLanguage.js'
 import { cloneDeep } from 'lodash-es'
 import { LosslessNumber } from 'lossless-json'
-import type { JSONValue } from '$lib/types.js'
 
 const { createQuery, executeQuery } = javascriptQueryLanguage
 
@@ -303,14 +302,14 @@ describe('javascriptQueryLanguage', () => {
 
     test('should work with alternative parsers and non-native JSON data types', () => {
       const data = [new LosslessNumber('4'), new LosslessNumber('7'), new LosslessNumber('5')]
-      const query = createQuery(data as unknown as JSONValue, {
+      const query = createQuery(data, {
         sort: {
           path: [],
           direction: 'asc'
         }
       })
 
-      const result = executeQuery(data as unknown as JSONValue, query, JSON)
+      const result = executeQuery(data, query, JSON)
       assert.deepStrictEqual(result, [
         new LosslessNumber('4'),
         new LosslessNumber('5'),

--- a/src/lib/plugins/query/javascriptQueryLanguage.ts
+++ b/src/lib/plugins/query/javascriptQueryLanguage.ts
@@ -1,6 +1,6 @@
 import { createPropertySelector } from '../../utils/pathUtils.js'
 import { parseString } from '../../utils/stringUtils.js'
-import type { JSONValue, QueryLanguage, QueryLanguageOptions } from '../../types.js'
+import type { QueryLanguage, QueryLanguageOptions } from '../../types.js'
 import { isInteger } from '../../utils/typeUtils.js'
 
 const description = `
@@ -17,7 +17,7 @@ export const javascriptQueryLanguage: QueryLanguage = {
   executeQuery
 }
 
-function createQuery(json: JSONValue, queryOptions: QueryLanguageOptions): string {
+function createQuery(json: unknown, queryOptions: QueryLanguageOptions): string {
   const { filter, sort, projection } = queryOptions
   const queryParts = ['  return data\n']
 
@@ -83,7 +83,7 @@ function createQuery(json: JSONValue, queryOptions: QueryLanguageOptions): strin
   return `function query (data) {\n${queryParts.join('')}}`
 }
 
-function executeQuery(json: JSONValue, query: string): JSONValue {
+function executeQuery(json: unknown, query: string): unknown {
   // FIXME: replace unsafe new Function with a JS based query language
   //  As long as we don't persist or fetch queries, there is no security risk.
   // TODO: only import the most relevant subset of lodash instead of the full library?

--- a/src/lib/plugins/query/jmespathQueryLanguage.test.ts
+++ b/src/lib/plugins/query/jmespathQueryLanguage.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'vitest'
 import { jmespathQueryLanguage } from './jmespathQueryLanguage.js'
 import { cloneDeep } from 'lodash-es'
 import { LosslessNumber, parse, stringify } from 'lossless-json'
-import type { JSONParser, JSONValue } from '$lib/types'
+import type { JSONParser } from '$lib/types'
 
 const { createQuery, executeQuery } = jmespathQueryLanguage
 
@@ -241,7 +241,7 @@ describe('jmespathQueryLanguage', () => {
     const LosslessJSONParser = { parse, stringify } as JSONParser
 
     const data = [new LosslessNumber('4'), new LosslessNumber('7'), new LosslessNumber('5')]
-    const query = createQuery(data as unknown as JSONValue, {
+    const query = createQuery(data, {
       sort: {
         path: [],
         direction: 'asc'
@@ -249,7 +249,7 @@ describe('jmespathQueryLanguage', () => {
     })
 
     // JMESPath does not support LosslessNumber, and executeQuery will convert into numbers first
-    const result = executeQuery(data as unknown as JSONValue, query, LosslessJSONParser)
+    const result = executeQuery(data, query, LosslessJSONParser)
     assert.deepStrictEqual(result, [4, 5, 7])
   })
 })

--- a/src/lib/plugins/query/jmespathQueryLanguage.test.ts
+++ b/src/lib/plugins/query/jmespathQueryLanguage.test.ts
@@ -3,7 +3,6 @@ import { describe, test } from 'vitest'
 import { jmespathQueryLanguage } from './jmespathQueryLanguage.js'
 import { cloneDeep } from 'lodash-es'
 import { LosslessNumber, parse, stringify } from 'lossless-json'
-import type { JSONParser } from '$lib/types'
 
 const { createQuery, executeQuery } = jmespathQueryLanguage
 
@@ -238,7 +237,7 @@ describe('jmespathQueryLanguage', () => {
   })
 
   test('should work with alternative parsers and non-native JSON data types', () => {
-    const LosslessJSONParser = { parse, stringify } as JSONParser
+    const LosslessJSONParser = { parse, stringify }
 
     const data = [new LosslessNumber('4'), new LosslessNumber('7'), new LosslessNumber('5')]
     const query = createQuery(data, {

--- a/src/lib/plugins/query/jmespathQueryLanguage.ts
+++ b/src/lib/plugins/query/jmespathQueryLanguage.ts
@@ -100,7 +100,13 @@ function createQuery(json: unknown, queryOptions: QueryLanguageOptions): string 
  */
 function executeQuery(json: unknown, query: string, parser: JSONParser): unknown {
   // JMESPath cannot handle non-native JSON data types like LosslessNumber
-  const preprocessedJson = isEqualParser(parser, JSON) ? json : JSON.parse(parser.stringify(json))
+
+  function stringifyAndParse(json: unknown) {
+    const text = parser.stringify(json)
+    return text !== undefined ? JSON.parse(text) : undefined
+  }
+
+  const preprocessedJson = isEqualParser(parser, JSON) ? json : stringifyAndParse(json)
 
   return jmespath.search(preprocessedJson, query)
 }

--- a/src/lib/plugins/query/jmespathQueryLanguage.ts
+++ b/src/lib/plugins/query/jmespathQueryLanguage.ts
@@ -2,7 +2,7 @@ import jmespath from 'jmespath'
 import type { JSONPath } from 'immutable-json-patch'
 import { getIn } from 'immutable-json-patch'
 import { parseString } from '$lib/utils/stringUtils.js'
-import type { JSONParser, JSONValue, QueryLanguage, QueryLanguageOptions } from '$lib/types'
+import type { JSONParser, QueryLanguage, QueryLanguageOptions } from '$lib/types'
 import { isEqualParser } from '$lib/utils/jsonUtils.js'
 
 const description = `
@@ -29,7 +29,7 @@ export const jmespathQueryLanguage: QueryLanguage = {
  * @param queryOptions
  * @return Returns a query (as string)
  */
-function createQuery(json: JSONValue, queryOptions: QueryLanguageOptions): string {
+function createQuery(json: unknown, queryOptions: QueryLanguageOptions): string {
   const { sort, filter, projection } = queryOptions
   let query = ''
 
@@ -98,7 +98,7 @@ function createQuery(json: JSONValue, queryOptions: QueryLanguageOptions): strin
 /**
  * Execute a JMESPath query, returns the transformed JSON
  */
-function executeQuery(json: JSONValue, query: string, parser: JSONParser): JSONValue {
+function executeQuery(json: unknown, query: string, parser: JSONParser): unknown {
   // JMESPath cannot handle non-native JSON data types like LosslessNumber
   const preprocessedJson = isEqualParser(parser, JSON) ? json : JSON.parse(parser.stringify(json))
 

--- a/src/lib/plugins/query/lodashQueryLanguage.test.ts
+++ b/src/lib/plugins/query/lodashQueryLanguage.test.ts
@@ -3,7 +3,6 @@ import assert from 'assert'
 import { lodashQueryLanguage } from './lodashQueryLanguage.js'
 import { cloneDeep } from 'lodash-es'
 import { LosslessNumber, parse, stringify } from 'lossless-json'
-import type { JSONParser } from '$lib/types'
 
 const { createQuery, executeQuery } = lodashQueryLanguage
 
@@ -361,7 +360,7 @@ describe('lodashQueryLanguage', () => {
     })
 
     test('should work with alternative parsers and non-native JSON data types', () => {
-      const LosslessJSONParser = { parse, stringify } as JSONParser
+      const LosslessJSONParser = { parse, stringify }
 
       const data = [new LosslessNumber('4'), new LosslessNumber('7'), new LosslessNumber('5')]
       const query = createQuery(data, {

--- a/src/lib/plugins/query/lodashQueryLanguage.test.ts
+++ b/src/lib/plugins/query/lodashQueryLanguage.test.ts
@@ -3,7 +3,7 @@ import assert from 'assert'
 import { lodashQueryLanguage } from './lodashQueryLanguage.js'
 import { cloneDeep } from 'lodash-es'
 import { LosslessNumber, parse, stringify } from 'lossless-json'
-import type { JSONParser, JSONValue } from '$lib/types'
+import type { JSONParser } from '$lib/types'
 
 const { createQuery, executeQuery } = lodashQueryLanguage
 
@@ -336,27 +336,27 @@ describe('lodashQueryLanguage', () => {
 
     test('should sort a list with numbers', () => {
       const data = [4, 7, 5]
-      const query = createQuery(data as unknown as JSONValue, {
+      const query = createQuery(data, {
         sort: {
           path: [],
           direction: 'asc'
         }
       })
 
-      const result = executeQuery(data as unknown as JSONValue, query, JSON)
+      const result = executeQuery(data, query, JSON)
       assert.deepStrictEqual(result, [4, 5, 7])
     })
 
     test('should sort empty keys by value', () => {
       const data = [{ '': 4 }, { '': 7 }, { '': 5 }]
-      const query = createQuery(data as unknown as JSONValue, {
+      const query = createQuery(data, {
         sort: {
           path: [''],
           direction: 'asc'
         }
       })
 
-      const result = executeQuery(data as unknown as JSONValue, query, JSON)
+      const result = executeQuery(data, query, JSON)
       assert.deepStrictEqual(result, [{ '': 4 }, { '': 5 }, { '': 7 }])
     })
 
@@ -364,14 +364,14 @@ describe('lodashQueryLanguage', () => {
       const LosslessJSONParser = { parse, stringify } as JSONParser
 
       const data = [new LosslessNumber('4'), new LosslessNumber('7'), new LosslessNumber('5')]
-      const query = createQuery(data as unknown as JSONValue, {
+      const query = createQuery(data, {
         sort: {
           path: [],
           direction: 'asc'
         }
       })
 
-      const result = executeQuery(data as unknown as JSONValue, query, LosslessJSONParser)
+      const result = executeQuery(data, query, LosslessJSONParser)
       assert.deepStrictEqual(result, [
         new LosslessNumber('4'),
         new LosslessNumber('5'),

--- a/src/lib/plugins/query/lodashQueryLanguage.ts
+++ b/src/lib/plugins/query/lodashQueryLanguage.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es'
 import { last } from 'lodash-es'
 import { createLodashPropertySelector, createPropertySelector } from '../../utils/pathUtils.js'
 import { parseString } from '../../utils/stringUtils.js'
-import type { JSONValue, QueryLanguage, QueryLanguageOptions } from '../../types.js'
+import type { QueryLanguage, QueryLanguageOptions } from '../../types.js'
 import { isInteger } from '../../utils/typeUtils.js'
 
 const description = `
@@ -23,7 +23,7 @@ export const lodashQueryLanguage: QueryLanguage = {
   executeQuery
 }
 
-function createQuery(json: JSONValue, queryOptions: QueryLanguageOptions): string {
+function createQuery(json: unknown, queryOptions: QueryLanguageOptions): string {
   const { filter, sort, projection } = queryOptions
   const queryParts = ['  return _.chain(data)\n']
 
@@ -70,7 +70,7 @@ function createQuery(json: JSONValue, queryOptions: QueryLanguageOptions): strin
   return `function query (data) {\n${queryParts.join('')}}`
 }
 
-function executeQuery(json: JSONValue, query: string): JSONValue {
+function executeQuery(json: unknown, query: string): unknown {
   validate(query)
 
   // FIXME: replace unsafe new Function with a JS based query language

--- a/src/lib/plugins/validator/createAjvValidator.ts
+++ b/src/lib/plugins/validator/createAjvValidator.ts
@@ -2,13 +2,7 @@ import type Ajv from 'ajv'
 import type { Options, Schema, ErrorObject } from 'ajv'
 import AjvDist from 'ajv'
 import { parsePath } from 'immutable-json-patch'
-import type {
-  JSONSchema,
-  JSONSchemaDefinitions,
-  JSONValue,
-  ValidationError,
-  Validator
-} from '$lib/types'
+import type { JSONSchema, JSONSchemaDefinitions, ValidationError, Validator } from '$lib/types'
 import { ValidationSeverity } from '$lib/types.js'
 
 export interface AjvValidatorOptions {
@@ -63,7 +57,7 @@ export function createAjvValidator(options: AjvValidatorOptions): Validator {
     throw validateAjv.errors[0]
   }
 
-  return function validate(json: JSONValue): ValidationError[] {
+  return function validate(json: unknown): ValidationError[] {
     validateAjv(json)
     const ajvErrors = validateAjv.errors || []
 
@@ -90,7 +84,7 @@ function createAjvInstance(options: AjvValidatorOptions): Ajv {
   return ajv
 }
 
-function normalizeAjvError(json: JSONValue, ajvError: ErrorObject): ValidationError {
+function normalizeAjvError(json: unknown, ajvError: ErrorObject): ValidationError {
   return {
     path: parsePath(json, ajvError.instancePath),
     message: ajvError.message || 'Unknown error',

--- a/src/lib/plugins/value/components/BooleanToggle.svelte
+++ b/src/lib/plugins/value/components/BooleanToggle.svelte
@@ -5,10 +5,10 @@
   import type { JSONPath } from 'immutable-json-patch'
   import { compileJSONPointer } from 'immutable-json-patch'
   import Icon from 'svelte-awesome'
-  import type { JSONValue, OnPatch } from '$lib/types.js'
+  import type { OnPatch } from '$lib/types.js'
 
   export let path: JSONPath
-  export let value: JSONValue
+  export let value: unknown
   export let readOnly: boolean
   export let onPatch: OnPatch
   export let focus: () => void

--- a/src/lib/plugins/value/components/EditableValue.svelte
+++ b/src/lib/plugins/value/components/EditableValue.svelte
@@ -10,7 +10,6 @@
   import type {
     FindNextInside,
     JSONParser,
-    JSONValue,
     OnFind,
     OnJSONSelect,
     OnPasteJson,
@@ -21,7 +20,7 @@
   import { isEqual } from 'lodash-es'
 
   export let path: JSONPath
-  export let value: JSONValue
+  export let value: unknown
   export let parser: JSONParser
   export let normalization: ValueNormalization
   export let enforceString: boolean
@@ -32,7 +31,7 @@
   export let focus: () => void
   export let findNextInside: FindNextInside
 
-  function convert(value: string): JSONValue {
+  function convert(value: string): unknown {
     return enforceString ? value : stringConvert(value, parser)
   }
 
@@ -81,7 +80,7 @@
       if (isObjectOrArray(pastedJson)) {
         onPasteJson({
           path,
-          contents: pastedJson as JSONValue
+          contents: pastedJson
         })
       }
     } catch (err) {

--- a/src/lib/plugins/value/components/EnumValue.svelte
+++ b/src/lib/plugins/value/components/EnumValue.svelte
@@ -4,11 +4,11 @@
   import type { JSONPath } from 'immutable-json-patch'
   import { compileJSONPointer } from 'immutable-json-patch'
   import { getValueClass } from '$lib/plugins/value/components/utils/getValueClass.js'
-  import type { JSONParser, JSONSelection, JSONValue, OnPatch } from '$lib/types.js'
+  import type { JSONParser, JSONSelection, OnPatch } from '$lib/types.js'
   import { isValueSelection } from '$lib/logic/selection.js'
 
   export let path: JSONPath
-  export let value: JSONValue
+  export let value: unknown
   export let parser: JSONParser
   export let readOnly: boolean
   export let selection: JSONSelection | null
@@ -18,7 +18,7 @@
 
   let refSelect: HTMLSelectElement | undefined
 
-  let bindValue: JSONValue = value
+  let bindValue: unknown = value
   $: bindValue = value
 
   function applyFocus(selection: JSONSelection | null) {
@@ -31,7 +31,7 @@
 
   $: applyFocus(selection)
 
-  function handleSelect(event) {
+  function handleSelect(event: Event) {
     event.stopPropagation()
 
     if (readOnly) {
@@ -47,7 +47,7 @@
     ])
   }
 
-  function handleMouseDown(event) {
+  function handleMouseDown(event: MouseEvent) {
     // stop propagation to prevent selecting the whole line
     event.stopPropagation()
   }

--- a/src/lib/plugins/value/components/ReadonlyValue.svelte
+++ b/src/lib/plugins/value/components/ReadonlyValue.svelte
@@ -9,14 +9,13 @@
   import type {
     ExtendedSearchResultItem,
     JSONParser,
-    JSONValue,
     OnJSONSelect,
     ValueNormalization
   } from '$lib/types.js'
   import type { JSONPath } from 'immutable-json-patch'
 
   export let path: JSONPath
-  export let value: JSONValue
+  export let value: unknown
   export let readOnly: boolean
   export let normalization: ValueNormalization
   export let parser: JSONParser

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -244,16 +244,16 @@ export interface QueryLanguage {
 
 export interface QueryLanguageOptions {
   filter?: {
-    path?: string[]
+    path?: JSONPath
     relation?: '==' | '!=' | '<' | '<=' | '>' | '>='
     value?: string
   }
   sort?: {
-    path?: string[]
+    path?: JSONPath
     direction?: 'asc' | 'desc'
   }
   projection?: {
-    paths?: string[][]
+    paths?: JSONPath[]
   }
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -267,7 +267,10 @@ export type OnChange =
   | null
 export type OnJSONSelect = (selection: JSONSelection) => void
 export type OnSelect = (selection: JSONEditorSelection | null) => void
-export type OnPatch = (operations: JSONPatchDocument, afterPatch?: AfterPatchCallback) => void
+export type OnPatch = (
+  operations: JSONPatchDocument,
+  afterPatch?: AfterPatchCallback
+) => JSONPatchResult
 export type OnChangeText = (updatedText: string, afterPatch?: AfterPatchCallback) => void
 export type OnSort = (params: {
   operations: JSONPatchDocument
@@ -443,7 +446,7 @@ export interface JSONEditorContext {
   findElement: (path: JSONPath) => Element | null
   findNextInside: FindNextInside
   focus: () => void
-  onPatch: (operations: JSONPatchDocument, afterPatch?: AfterPatchCallback) => JSONPatchResult
+  onPatch: OnPatch
   onSelect: OnJSONSelect
   onFind: OnFind
   onPasteJson: (newPastedJson: PastedJson) => void
@@ -473,7 +476,7 @@ export interface RenderValueProps {
   isEditing: boolean
   parser: JSONParser
   normalization: ValueNormalization
-  onPatch: TreeModeContext['onPatch']
+  onPatch: OnPatch
   onPasteJson: OnPasteJson
   onSelect: OnJSONSelect
   onFind: OnFind

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,13 +2,30 @@ import type { JSONPatchDocument, JSONPath, JSONPointer } from 'immutable-json-pa
 import type { SvelteComponent } from 'svelte'
 import type { IconDefinition } from '@fortawesome/free-solid-svg-icons'
 
-export type TextContent = { text: string } | { json: undefined; text: string }
+export type TextContent = { text: string }
 
-export type JSONContent = { json: unknown } | { json: unknown; text: undefined }
+export type JSONContent = { json: unknown }
 
 export type Content = JSONContent | TextContent
 
-export type JSONParser = JSON
+// The `JSONParser` interface is compatible with `JSON`,
+// except that JSON.stringify is wrongly defined to return a string whilst it can return a string or undefined
+// see: https://stackoverflow.com/questions/74461780/is-the-official-type-definition-for-json-stringify-wrong
+export interface JSONParser {
+  parse(
+    text: string,
+    reviver?: ((this: unknown, key: string, value: unknown) => unknown) | null
+  ): unknown
+
+  stringify(
+    value: unknown,
+    replacer?:
+      | ((this: unknown, key: string, value: unknown) => unknown)
+      | Array<number | string>
+      | null,
+    space?: string | number
+  ): string | undefined
+}
 
 export interface JSONPathParser {
   parse: (pathStr: string) => JSONPath

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,22 +2,9 @@ import type { JSONPatchDocument, JSONPath, JSONPointer } from 'immutable-json-pa
 import type { SvelteComponent } from 'svelte'
 import type { IconDefinition } from '@fortawesome/free-solid-svg-icons'
 
-// TODO: replace all usage of JSONValue with unknown since that is a more accurate type
-export type JSONPrimitive = string | number | boolean | null
-export type JSONValue =
-  | {
-      [key: string]: JSONValue
-    }
-  | JSONValue[]
-  | JSONPrimitive
-export type JSONObject = {
-  [key: string]: JSONValue
-}
-export type JSONArray = JSONValue[]
-
 export type TextContent = { text: string } | { json: undefined; text: string }
 
-export type JSONContent = { json: JSONValue } | { json: JSONValue; text: undefined }
+export type JSONContent = { json: unknown } | { json: unknown; text: undefined }
 
 export type Content = JSONContent | TextContent
 
@@ -79,16 +66,16 @@ export interface DocumentState {
 }
 
 export interface JSONPatchResult {
-  json: JSONValue
-  previousJson: JSONValue
+  json: unknown
+  previousJson: unknown
   undo: JSONPatchDocument
   redo: JSONPatchDocument
 }
 
 export type AfterPatchCallback = (
-  patchedJson: JSONValue,
+  patchedJson: unknown,
   patchedState: DocumentState
-) => { json?: JSONValue; state?: DocumentState } | undefined
+) => { json?: unknown; state?: DocumentState } | undefined
 
 export interface MultiSelection {
   type: SelectionType.multi
@@ -137,7 +124,7 @@ export type JSONEditorSelection = JSONSelection | TextSelection
 
 export type JSONPointerMap<T> = Record<JSONPointer, T>
 
-export type ClipboardValues = Array<{ key: string; value: JSONValue }>
+export type ClipboardValues = Array<{ key: string; value: unknown }>
 
 export interface MenuButton {
   type: 'button'
@@ -206,7 +193,7 @@ export interface NestedValidationError extends ValidationError {
   isChildError?: boolean
 }
 
-export type Validator = (json: JSONValue) => ValidationError[]
+export type Validator = (json: unknown) => ValidationError[]
 
 export interface ParseError {
   position: number | null
@@ -251,8 +238,8 @@ export interface QueryLanguage {
   id: string
   name: string
   description: string
-  createQuery: (json: JSONValue, queryOptions: QueryLanguageOptions) => string
-  executeQuery: (json: JSONValue, query: string, parser: JSONParser) => JSONValue
+  createQuery: (json: unknown, queryOptions: QueryLanguageOptions) => string
+  executeQuery: (json: unknown, query: string, parser: JSONParser) => unknown
 }
 
 export interface QueryLanguageOptions {
@@ -290,10 +277,10 @@ export type OnSort = (params: {
 }) => void
 export type OnFind = (findAndReplace: boolean) => void
 export type OnPaste = (pastedText: string) => void
-export type OnPasteJson = (pastedJson: { path: JSONPath; contents: JSONValue }) => void
+export type OnPasteJson = (pastedJson: { path: JSONPath; contents: unknown }) => void
 export type OnExpand = (path: JSONPath) => boolean
 export type OnRenderValue = (props: RenderValueProps) => RenderValueComponentDescription[]
-export type OnClassName = (path: JSONPath, value: JSONValue) => string | undefined
+export type OnClassName = (path: JSONPath, value: unknown) => string | undefined
 export type OnChangeMode = (mode: Mode) => void
 export type OnContextMenu = (contextMenuProps: AbsolutePopupOptions) => void
 export type RenderMenuContext = {
@@ -348,10 +335,10 @@ export interface ValueNormalization {
   unescapeValue: UnescapeValue
 }
 
-export type PastedJson = { contents: JSONValue; path: JSONPath } | undefined
+export type PastedJson = { contents: unknown; path: JSONPath } | undefined
 
 export interface DragInsideProps {
-  json: JSONValue
+  json: unknown
   selection: JSONSelection
   deltaY: number
   items: Array<{ path: JSONPath; height: number }>
@@ -369,14 +356,14 @@ export interface RenderedItem {
 export interface HistoryItem {
   undo: {
     patch: JSONPatchDocument | undefined
-    json: JSONValue | undefined
+    json: unknown | undefined
     text: string | undefined
     state: DocumentState
     textIsRepaired: boolean
   }
   redo: {
     patch: JSONPatchDocument | undefined
-    json: JSONValue | undefined
+    json: unknown | undefined
     text: string | undefined
     state: DocumentState
     textIsRepaired: boolean
@@ -451,7 +438,7 @@ export interface JSONEditorContext {
   readOnly: boolean
   parser: JSONParser
   normalization: ValueNormalization
-  getJson: () => JSONValue | undefined
+  getJson: () => unknown | undefined
   getDocumentState: () => DocumentState
   findElement: (path: JSONPath) => Element | null
   findNextInside: FindNextInside
@@ -464,7 +451,7 @@ export interface JSONEditorContext {
 }
 
 export interface TreeModeContext extends JSONEditorContext {
-  getJson: () => JSONValue | undefined
+  getJson: () => unknown | undefined
   getDocumentState: () => DocumentState
   findElement: (path: JSONPath) => Element | null
   onInsert: (type: InsertType) => void
@@ -478,7 +465,7 @@ export interface TreeModeContext extends JSONEditorContext {
 
 export interface RenderValuePropsOptional {
   path?: JSONPath
-  value?: JSONValue
+  value?: unknown
   readOnly?: boolean
   enforceString?: boolean
   selection?: JSONSelection | null
@@ -496,7 +483,7 @@ export interface RenderValuePropsOptional {
 
 export interface RenderValueProps extends RenderValuePropsOptional {
   path: JSONPath
-  value: JSONValue
+  value: unknown
   readOnly: boolean
   enforceString: boolean
   selection: JSONSelection | null
@@ -514,7 +501,7 @@ export interface RenderValueProps extends RenderValuePropsOptional {
 
 export interface JSONNodeProp {
   key: string
-  value: JSONValue
+  value: unknown
   path: JSONPath
   expandedMap: JSONPointerMap<boolean> | undefined
   enforceStringMap: JSONPointerMap<boolean> | undefined
@@ -527,7 +514,7 @@ export interface JSONNodeProp {
 
 export interface JSONNodeItem {
   index: number
-  value: JSONValue
+  value: unknown
   path: JSONPath
   expandedMap: JSONPointerMap<boolean> | undefined
   enforceStringMap: JSONPointerMap<boolean> | undefined
@@ -558,8 +545,8 @@ export interface TransformModalOptions {
   rootPath?: JSONPath
   onTransform?: (state: {
     operations: JSONPatchDocument
-    json: JSONValue
-    transformedJson: JSONValue
+    json: unknown
+    transformedJson: unknown
   }) => void
   onClose?: () => void
 }
@@ -567,14 +554,14 @@ export interface TransformModalOptions {
 export interface TransformModalCallback {
   id: string
   rootPath: JSONPath
-  json: JSONValue
+  json: unknown
   onTransform: (operations: JSONPatchDocument) => void
   onClose: () => void
 }
 
 export interface SortModalCallback {
   id: string
-  json: JSONValue
+  json: unknown
   rootPath: JSONPath
   onSort: OnSort
   onClose: () => void

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -463,25 +463,7 @@ export interface TreeModeContext extends JSONEditorContext {
   onDragEnd: () => void
 }
 
-export interface RenderValuePropsOptional {
-  path?: JSONPath
-  value?: unknown
-  readOnly?: boolean
-  enforceString?: boolean
-  selection?: JSONSelection | null
-  searchResultItems?: SearchResultItem[]
-  isEditing?: boolean
-  parser?: JSONParser
-  normalization?: ValueNormalization
-  onPatch?: TreeModeContext['onPatch']
-  onPasteJson?: OnPasteJson
-  onSelect?: OnJSONSelect
-  onFind?: OnFind
-  findNextInside?: FindNextInside
-  focus?: () => void
-}
-
-export interface RenderValueProps extends RenderValuePropsOptional {
+export interface RenderValueProps {
   path: JSONPath
   value: unknown
   readOnly: boolean
@@ -498,6 +480,8 @@ export interface RenderValueProps extends RenderValuePropsOptional {
   findNextInside: FindNextInside
   focus: () => void
 }
+
+export type RenderValuePropsOptional = Partial<RenderValueProps>
 
 export interface JSONNodeProp {
   key: string

--- a/src/lib/utils/arrayUtils.ts
+++ b/src/lib/utils/arrayUtils.ts
@@ -2,7 +2,6 @@ import { isObject } from './typeUtils.js'
 import type { JSONPath } from 'immutable-json-patch'
 import { compileJSONPointer, parseJSONPointer } from 'immutable-json-patch'
 import { isEqual } from 'lodash-es'
-import type { JSONArray, JSONObject, JSONValue } from '$lib/types.js'
 
 const MAX_ITEM_PATHS_COLLECTION = 10000
 const ROOT_PATH: JSONPath = []
@@ -65,14 +64,14 @@ export function compareArrays<T>(a: Array<T>, b: Array<T>): number {
  * @param array
  * @param includeObjects If true, object and array paths are returned as well
  */
-export function getNestedPaths(array: JSONValue, includeObjects = false): JSONPath[] {
+export function getNestedPaths(array: unknown, includeObjects = false): JSONPath[] {
   const pointersMap: Record<string, boolean> = {}
 
   if (!Array.isArray(array)) {
     throw new TypeError('Array expected')
   }
 
-  function recurseNestedPaths(obj: JSONValue, path: JSONPath) {
+  function recurseNestedPaths(obj: unknown, path: JSONPath) {
     const isValue = !Array.isArray(obj) && !isObject(obj)
 
     if (isValue || (includeObjects && path.length > 0)) {
@@ -125,17 +124,17 @@ export function limit<T>(array: Array<T>, max: number): Array<T> {
 /**
  * Convert an array into an object having the array indices as keys
  */
-export function arrayToObject(array: JSONArray): JSONObject {
+export function arrayToObject<T>(array: Array<T>): Record<number, T> {
   return {
     ...array
-  } as unknown as JSONObject
+  }
 }
 
 /**
  * Get the values of an object as an array
  */
-export function objectToArray(object: JSONObject): JSONArray {
-  return Object.values(object) as unknown as JSONArray
+export function objectToArray<T>(object: Record<string, T>): Array<T> {
+  return Object.values(object)
 }
 
 /**

--- a/src/lib/utils/jsonUtils.test.ts
+++ b/src/lib/utils/jsonUtils.test.ts
@@ -227,7 +227,7 @@ describe('jsonUtils', () => {
   test('isJSONContent', () => {
     strictEqual(isJSONContent({ text: '' }), false)
     strictEqual(isJSONContent({ json: [] }), true)
-    strictEqual(isJSONContent({ text: '', json: [] }), false) // text has precedence over json
+    strictEqual(isJSONContent({ text: '', json: [] }), true)
     strictEqual(isJSONContent(1), false)
     strictEqual(isJSONContent({}), false)
 
@@ -258,7 +258,7 @@ describe('jsonUtils', () => {
         // @ts-ignore
         { json: [new LosslessNumber('1'), new LosslessNumber('2'), new LosslessNumber('3')] },
         2,
-        LosslessJSONParser as JSONParser
+        LosslessJSONParser
       ),
       { text: '[\n  1,\n  2,\n  3\n]' }
     )
@@ -270,7 +270,7 @@ describe('jsonUtils', () => {
     deepStrictEqual(toJSONContent({ text: '[1,2,3]' }), jsonContent)
     strictEqual(toJSONContent(jsonContent), jsonContent)
 
-    deepStrictEqual(toJSONContent({ text: '[1,2,3]' }, LosslessJSONParser as JSONParser), {
+    deepStrictEqual(toJSONContent({ text: '[1,2,3]' }, LosslessJSONParser), {
       json: [new LosslessNumber('1'), new LosslessNumber('2'), new LosslessNumber('3')]
     })
 
@@ -279,7 +279,7 @@ describe('jsonUtils', () => {
     }, /(SyntaxError: Unexpected end of JSON input)|(SyntaxError: Expected ',' or ']' after array element in JSON at position 6)/)
 
     throws(() => {
-      toJSONContent({ text: '[1,2,3' }, LosslessJSONParser as JSONParser)
+      toJSONContent({ text: '[1,2,3' }, LosslessJSONParser)
     }, /SyntaxError: Array item or end of array ']' expected but reached end of input at position 6/)
   })
 
@@ -387,9 +387,8 @@ describe('jsonUtils', () => {
     })
 
     test('should test whether two parsers are equal', () => {
-      // FIXME: should not be needed to cast to JSONParser
-      const LosslessJSON = { parse, stringify } as JSONParser
-      const LosslessJSON2 = { parse, stringify } as JSONParser
+      const LosslessJSON = { parse, stringify }
+      const LosslessJSON2 = { parse, stringify }
 
       strictEqual(isEqualParser(JSON, JSON), true)
       strictEqual(isEqualParser(LosslessJSON, LosslessJSON), true)

--- a/src/lib/utils/jsonUtils.test.ts
+++ b/src/lib/utils/jsonUtils.test.ts
@@ -1,5 +1,4 @@
 import { test, describe, expect } from 'vitest'
-import type { JSONParser } from '$lib/types.js'
 import { deepStrictEqual, strictEqual, deepEqual, throws } from 'assert'
 import { LosslessNumber, parse, stringify } from 'lossless-json'
 import {

--- a/src/lib/utils/jsonUtils.test.ts
+++ b/src/lib/utils/jsonUtils.test.ts
@@ -258,7 +258,7 @@ describe('jsonUtils', () => {
         // @ts-ignore
         { json: [new LosslessNumber('1'), new LosslessNumber('2'), new LosslessNumber('3')] },
         2,
-        LosslessJSONParser
+        LosslessJSONParser as JSONParser
       ),
       { text: '[\n  1,\n  2,\n  3\n]' }
     )

--- a/src/lib/utils/jsonUtils.ts
+++ b/src/lib/utils/jsonUtils.ts
@@ -355,10 +355,10 @@ export function isTextContent(content: unknown): content is TextContent {
 }
 
 /**
- * Check whether content contains text (and not JSON)
+ * Check whether content contains json
  */
 export function isJSONContent(content: unknown): content is JSONContent {
-  return isObject(content) && typeof content.json !== 'undefined' && !isTextContent(content)
+  return isObject(content) && typeof content.json !== 'undefined'
 }
 
 /**
@@ -371,7 +371,7 @@ export function toTextContent(
 ): TextContent {
   return isTextContent(content)
     ? content
-    : { text: parser.stringify(content.json, null, indentation) }
+    : { text: parser.stringify(content.json, null, indentation) as string }
 }
 
 /**

--- a/src/lib/utils/jsonUtils.ts
+++ b/src/lib/utils/jsonUtils.ts
@@ -9,9 +9,7 @@ import { arrayToObject, objectToArray } from './arrayUtils.js'
 import type {
   Content,
   JSONContent,
-  JSONObject,
   JSONParser,
-  JSONValue,
   ParseError,
   TextContent,
   TextLocation
@@ -229,10 +227,10 @@ export function findTextLocation(text: string, path: JSONPath): TextLocation | n
  * If it cannot be converted, an error is thrown
  */
 export function convertValue(
-  value: JSONValue,
+  value: unknown,
   type: 'value' | 'object' | 'array',
   parser: JSONParser
-): JSONValue {
+): unknown {
   // FIXME: improve the TypeScript here, there are a couple of conversions
   if (type === 'array') {
     if (Array.isArray(value)) {
@@ -282,7 +280,7 @@ export function convertValue(
         const parsedValue = parser.parse(value)
 
         if (isObject(parsedValue)) {
-          return parsedValue as JSONObject
+          return parsedValue
         }
 
         if (Array.isArray(parsedValue)) {
@@ -418,7 +416,7 @@ export function estimateSerializedSize(content: Content, maxSize = Infinity): nu
 
   let estimatedSize = 0
 
-  function recurse(json: JSONValue) {
+  function recurse(json: unknown) {
     if (Array.isArray(json)) {
       // open and close bracket, commas between items
       estimatedSize += 2 + (json.length - 1)

--- a/src/lib/utils/localStorageUtils.ts
+++ b/src/lib/utils/localStorageUtils.ts
@@ -1,14 +1,13 @@
 import { writable } from 'svelte/store'
-import type { JSONValue } from '$lib/types.js'
 
-export function useLocalStorage(key: string, defaultValue: JSONValue) {
+export function useLocalStorage(key: string, defaultValue: unknown) {
   const initialValue = loadFromLocalStorage(key, defaultValue)
   const store = writable(initialValue)
   store.subscribe((value) => saveToLocalStorage(key, value))
   return store
 }
 
-function loadFromLocalStorage(key: string, defaultValue: JSONValue) {
+function loadFromLocalStorage(key: string, defaultValue: unknown) {
   if (typeof localStorage === 'undefined') {
     return defaultValue
   }
@@ -22,7 +21,7 @@ function loadFromLocalStorage(key: string, defaultValue: JSONValue) {
   }
 }
 
-function saveToLocalStorage(key: string, value: JSONValue) {
+function saveToLocalStorage(key: string, value: unknown) {
   if (typeof localStorage === 'undefined') {
     return
   }

--- a/src/lib/utils/objectUtils.test.ts
+++ b/src/lib/utils/objectUtils.test.ts
@@ -3,7 +3,6 @@ import { deepStrictEqual, strictEqual } from 'assert'
 import { traverse } from './objectUtils.js'
 import { isEqual } from 'lodash-es'
 import type { JSONPath } from 'immutable-json-patch'
-import type { JSONValue } from '$lib/types.js'
 
 describe('objectUtils', () => {
   const json = {
@@ -16,7 +15,7 @@ describe('objectUtils', () => {
   }
 
   test('traverse', () => {
-    const logs: Array<{ value: JSONValue; path: JSONPath }> = []
+    const logs: Array<{ value: unknown; path: JSONPath }> = []
 
     traverse(json, (value, path, context) => {
       strictEqual(context, json)
@@ -44,7 +43,7 @@ describe('objectUtils', () => {
       },
       e: 5
     }
-    const logs: Array<{ value: JSONValue; path: JSONPath }> = []
+    const logs: Array<{ value: unknown; path: JSONPath }> = []
 
     traverse(json, (value, path, context) => {
       strictEqual(context, json)

--- a/src/lib/utils/objectUtils.ts
+++ b/src/lib/utils/objectUtils.ts
@@ -1,14 +1,13 @@
 import type { JSONPath } from 'immutable-json-patch'
 import { isObject } from './typeUtils.js'
-import type { JSONValue } from '$lib/types.js'
 
 export function traverse(
-  json: JSONValue,
-  callback: (value: JSONValue, path: JSONPath, json: JSONValue) => boolean | void
+  json: unknown,
+  callback: (value: unknown, path: JSONPath, json: unknown) => boolean | void
 ) {
   const currentPath: JSONPath = []
 
-  function recurse(value: JSONValue) {
+  function recurse(value: unknown) {
     const res = callback(value, currentPath, json)
     if (res === false) {
       return

--- a/src/lib/utils/typeUtils.ts
+++ b/src/lib/utils/typeUtils.ts
@@ -1,7 +1,7 @@
 // TODO: unit test typeUtils.js
 
 import { isNumber } from './numberUtils.js'
-import type { JSONParser, JSONValue } from '../types.js'
+import type { JSONParser } from '../types.js'
 
 /**
  * Test whether a value is an Object (and not an Array or Class)
@@ -151,7 +151,7 @@ export function isUrl(text: unknown): boolean {
  * Convert contents of a string to the correct JSON type. This can be a string,
  * a number, a boolean, etc
  */
-export function stringConvert(str: string, parser: JSONParser): JSONValue {
+export function stringConvert(str: string, parser: JSONParser): unknown {
   if (str === '') {
     return ''
   }

--- a/src/routes/development/+page.svelte
+++ b/src/routes/development/+page.svelte
@@ -26,11 +26,7 @@
   import { parse, stringify } from 'lossless-json'
   import { truncate } from '$lib/utils/stringUtils.js'
   import { parseJSONPath, stringifyJSONPath } from '$lib/utils/pathUtils.js'
-  import {
-    compileJSONPointer,
-    isJSONObject,
-    parseJSONPointer
-  } from 'immutable-json-patch'
+  import { compileJSONPointer, isJSONObject, parseJSONPointer } from 'immutable-json-patch'
   import { toJSONContent } from '$lib/utils/jsonUtils.js'
   import { isJSONContent, isTextContent } from '$lib'
 
@@ -447,7 +443,7 @@
     })
   }
 
-  function handleOpenFile (event: Event) {
+  function handleOpenFile(event: Event) {
     const target = event.target as HTMLInputElement
 
     console.log('loadFile', target.files)

--- a/src/routes/development/+page.svelte
+++ b/src/routes/development/+page.svelte
@@ -29,19 +29,15 @@
   import {
     compileJSONPointer,
     isJSONObject,
-    type JSONArray,
-    type JSONObject,
     parseJSONPointer
   } from 'immutable-json-patch'
   import { toJSONContent } from '$lib/utils/jsonUtils.js'
   import { isJSONContent, isTextContent } from '$lib'
-  import type { ChangeEventHandler } from 'svelte/elements.js'
 
-  // const LosslessJSON: JSONParser = { ... } // FIXME: make the types work
   const LosslessJSON = {
     parse,
     stringify
-  } as JSONParser
+  }
 
   let content: Content = {
     text: `{
@@ -412,7 +408,7 @@
     }
   }
 
-  function generateLongArray(): JSONArray {
+  function generateLongArray() {
     return [...new Array(1000)].map((value, index) => {
       const random = Math.round(Math.random() * 1000)
       const item: Record<string, unknown> = {
@@ -447,11 +443,11 @@
         item.unknownProp = 'other'
       }
 
-      return item as JSONObject
+      return item
     })
   }
 
-  const handleOpenFile: ChangeEventHandler<HTMLInputElement> = (event) => {
+  function handleOpenFile (event: Event) {
     const target = event.target as HTMLInputElement
 
     console.log('loadFile', target.files)
@@ -800,7 +796,7 @@
           <pre>
             <code>
             {isJSONContent(content)
-                ? truncate(selectedParser.stringify(content.json, null, 2), 1e5)
+                ? truncate(selectedParser.stringify(content.json, null, 2) ?? '', 1e5)
                 : 'undefined'}
             </code>
           </pre>


### PR DESCRIPTION
**BREAKING CHANGES IN THE TYPE DEFINITIONS**

The `JSONValue` type is too limited, for example when using the `lossless-json` parser instead of `JSON`, there can be instances of `LosslessNumber`. Other parsers may generated `BigInt` instances, etc. Therefore, defining `json` as `unknown` is more "accurate".

So the following (core) type definitions: 

```ts
export type TextContent = { text: string } | { json: undefined; text: string }
export type JSONContent = { json: unknown } | { json: unknown; text: undefined }
export type Content = JSONContent | TextContent
```

Will now become:

```ts
export type TextContent = { text: string }
export type JSONContent = { json: unknown }
export type Content = JSONContent | TextContent
``` 

Also, the type of `JSONParser` is changed from `type JSONParser = JSON` to an explicit description, which has one difference with `JSON.stringify` namely that it can return `string | undefined` instead of `string`. The current official type definition of `JSON` is lacking in this regard: `JSON.stringify(undefined)` returns `undefined`, but this is not reflected in the type, which can lead to a false sense of null-safety. See: https://stackoverflow.com/questions/74461780/is-the-official-type-definition-for-json-stringify-wrong.

All in all, this should result in a more smooth TypeScript experience and less need for type casting.