### PR TITLE
feat: do not trigger onChange on programmatic changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Callback fired when an error occurs. Default implementation is to log an error i
 onChange(content: Content, previousContent: Content, changeStatus: { contentErrors: ContentErrors | null, patchResult: JSONPatchResult | null })
 ```
 
-The callback which is invoked on every change of the contents, both changes made by a user and programmatic changes made via methods like `.set()`, `.update()`, or `.patch()`.
+The callback which is invoked on every change of the contents made by the user from within the editor. It will not trigger on changes that are applied programmatically via methods like `.set()`, `.update()`, or `.patch()`.
 
 The returned `content` is sometimes of type `{ json }`, and sometimes of type `{ text }`. Which of the two is returned depends on the mode of the editor, the change that is applied, and the state of the document (valid, invalid, empty). Please be aware that `{ text }` can contain invalid JSON: whilst typing in `text` mode, a JSON document will be temporarily invalid, like when the user is typing a new string. The parameter `patchResult` is only returned on changes that can be represented as a JSON Patch document, and for example not when freely typing in `text` mode.
 

--- a/src/lib/components/modes/tablemode/TableMode.svelte
+++ b/src/lib/components/modes/tablemode/TableMode.svelte
@@ -371,7 +371,6 @@
       return
     }
 
-    const previousContent = { json, text }
     const previousJson = json
     const previousState = documentState
     const previousText = text

--- a/src/lib/components/modes/tablemode/TableMode.svelte
+++ b/src/lib/components/modes/tablemode/TableMode.svelte
@@ -419,13 +419,6 @@
       previousText,
       previousTextIsRepaired
     })
-
-    // we could work out a patchResult, or use patch(), but only when the previous and new
-    // contents are both json and not text. We go for simplicity and consistency here and
-    // let the function applyExternalContent _not_ return a patchResult ever.
-    const patchResult = null
-
-    emitOnChange(previousContent, patchResult)
   }
 
   function applyExternalSelection(externalSelection: JSONEditorSelection | null) {
@@ -580,7 +573,6 @@
       throw new Error('Cannot apply patch: no JSON')
     }
 
-    const previousContent: Content = { json }
     const previousJson = json
     const previousState = documentState
     const previousTextIsRepaired = textIsRepaired
@@ -638,8 +630,6 @@
       redo: operations
     }
 
-    emitOnChange(previousContent, patchResult)
-
     return patchResult
   }
 
@@ -647,17 +637,14 @@
     operations: JSONPatchDocument,
     afterPatch?: AfterPatchCallback
   ): JSONPatchResult {
-    if (readOnly) {
-      // this should never happen in practice
-      return {
-        json,
-        previousJson: json,
-        redo: [],
-        undo: []
-      }
-    }
+    debug('handlePatch', operations, afterPatch)
 
-    return patch(operations, afterPatch)
+    const previousContent = { json, text }
+    const patchResult = patch(operations, afterPatch)
+
+    emitOnChange(previousContent, patchResult)
+
+    return patchResult
   }
 
   function emitOnChange(previousContent: Content, patchResult: JSONPatchResult | null) {

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -514,7 +514,6 @@
       return
     }
 
-    const previousContent: Content = { json, text }
     const previousState = documentState
     const previousJson = json
     const previousText = text
@@ -549,7 +548,6 @@
       return
     }
 
-    const previousContent: Content = { json, text }
     const previousJson = json
     const previousState = documentState
     const previousText = text

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -533,14 +533,6 @@
       previousText,
       previousTextIsRepaired
     })
-
-    // we could work out a patchResult, or use patch(), but only when the previous and new
-    // contents are both json and not text. We go for simplicity and consistency here and
-    // let the functions applyExternalJson and applyExternalText _not_ return
-    // a patchResult ever.
-    const patchResult = null
-
-    emitOnChange(previousContent, patchResult)
   }
 
   function applyExternalText(updatedText: string | undefined) {
@@ -597,14 +589,6 @@
       previousText,
       previousTextIsRepaired
     })
-
-    // we could work out a patchResult, or use patch(), but only when the previous and new
-    // contents are both json and not text. We go for simplicity and consistency here and
-    // let the functions applyExternalJson and applyExternalText _not_ return
-    // a patchResult ever.
-    const patchResult = null
-
-    emitOnChange(previousContent, patchResult)
   }
 
   function applyExternalSelection(externalSelection: JSONEditorSelection | null) {
@@ -739,7 +723,6 @@
       throw new Error('Cannot apply patch: no JSON')
     }
 
-    const previousContent = { json, text }
     const previousJson = json
     const previousState = documentState
     const previousText = text
@@ -799,8 +782,6 @@
       undo,
       redo: operations
     }
-
-    emitOnChange(previousContent, patchResult)
 
     return patchResult
   }
@@ -1451,19 +1432,14 @@
     operations: JSONPatchDocument,
     afterPatch?: AfterPatchCallback
   ): JSONPatchResult {
-    if (readOnly) {
-      // this should never happen in practice
-      return {
-        json,
-        previousJson: json,
-        undo: [],
-        redo: []
-      }
-    }
-
     debug('handlePatch', operations, afterPatch)
 
-    return patch(operations, afterPatch)
+    const previousContent = { json, text }
+    const patchResult = patch(operations, afterPatch)
+
+    emitOnChange(previousContent, patchResult)
+
+    return patchResult
   }
 
   function handleReplaceJson(updatedJson: unknown, afterPatch?: AfterPatchCallback) {


### PR DESCRIPTION
This PR changed the behavior of the editor to _NOT_ emit `onChange` events on programmatic changes. It will only emit `onChange` on user changes, similar to for example the HTML `<input />` component. See: https://github.com/josdejong/svelte-jsoneditor/issues/318#issuecomment-1818817968.

This will make #145 irrelevant, and will partially resolve #318.

For reference: this behavior was introduced after a discussion in #128 via PR #134.

⚠️ **THIS IS A BREAKING CHANGE**⚠️ 