### PR TITLE
Refactor the API to use `undefined` instead of `null`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,14 @@
     "sourceType": "module",
     "ecmaVersion": 2019
   },
+  "rules": {
+    "consistent-return": [
+      "warn",
+      {
+        "treatUndefinedAsUnspecified": false
+      }
+    ]
+  },
   "overrides": [
     {
       "files": ["*.svelte"],

--- a/README-VANILLA.md
+++ b/README-VANILLA.md
@@ -2,7 +2,7 @@
 
 A web-based tool to view, edit, format, transform, and validate JSON.
 
-Try it out: https://jsoneditoronline.org
+Try it out: <https://jsoneditoronline.org>
 
 This is the vanilla variant of `svelte-jsoneditor`, which can be used in vanilla JavaScript or frameworks like SolidJS, React, Vue, Angular.
 
@@ -50,7 +50,7 @@ import { JSONEditor } from 'vanilla-jsoneditor/standalone.js'
 
 The standalone bundle contains all dependencies of `vanilla-jsoneditor`, for example `lodash-es` and `Ajv`. If you use some of these dependencies in your project too, it means that they will be bundled twice in your web application, leading to a needlessly large application size. In general, it is preferable to use the default `import { JSONEditor } from 'vanilla-jsoneditor'` so dependencies can be reused.
 
-## Use (Browser example loading the ES module):
+## Use (Browser example loading the ES module)
 
 ```html
 <!doctype html>
@@ -100,7 +100,7 @@ The standalone bundle contains all dependencies of `vanilla-jsoneditor`, for exa
 
 Depending on whether you are using JavaScript of TypeScript, create either a JSX or TSX file:
 
-### TypeScript:
+### TypeScript
 
 ```tsx
 //
@@ -111,7 +111,7 @@ import { JSONEditor, JSONEditorPropsOptional } from 'vanilla-jsoneditor'
 
 const JSONEditorReact: React.FC<JSONEditorPropsOptional> = (props) => {
   const refContainer = useRef<HTMLDivElement>(null)
-  const refEditor = useRef<JSONEditor | undefined>(null)
+  const refEditor = useRef<JSONEditor | null>(null)
 
   useEffect(() => {
     // create editor

--- a/README-VANILLA.md
+++ b/README-VANILLA.md
@@ -111,7 +111,7 @@ import { JSONEditor, JSONEditorPropsOptional } from 'vanilla-jsoneditor'
 
 const JSONEditorReact: React.FC<JSONEditorPropsOptional> = (props) => {
   const refContainer = useRef<HTMLDivElement>(null)
-  const refEditor = useRef<JSONEditor | null>(null)
+  const refEditor = useRef<JSONEditor | undefined>(null)
 
   useEffect(() => {
     // create editor

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Pass the JSON contents to be rendered in the JSONEditor. `Content` is an object 
 #### selection
 
 ```ts
-selection: JSONEditorSelection | null
+selection: JSONEditorSelection | undefined
 ```
 
 The current selected contents. You can use two-way binding using `bind:selection`. The `tree` mode supports `MultiSelection`, `KeySelection`, `ValueSelection`, `InsideSelection`, or `AfterSelection`. The `table` mode supports `ValueSelection`, and `text` mode supports `TextSelection.`.
@@ -386,7 +386,7 @@ Callback fired when an error occurs. Default implementation is to log an error i
 #### onChange
 
 ```ts
-onChange(content: Content, previousContent: Content, changeStatus: { contentErrors: ContentErrors | null, patchResult: JSONPatchResult | null })
+onChange(content: Content, previousContent: Content, changeStatus: { contentErrors: ContentErrors | undefined, patchResult: JSONPatchResult | undefined })
 ```
 
 The callback which is invoked on every change of the contents made by the user from within the editor. It will not trigger on changes that are applied programmatically via methods like `.set()`, `.update()`, or `.patch()`.
@@ -519,7 +519,7 @@ A menu item `MenuItem` can be one of the following types:
 #### onRenderContextMenu
 
 ```ts
-onRenderContextMenu(items: ContextMenuItem[], context: { mode: 'tree' | 'text' | 'table', modal: boolean, readOnly: boolean, selection: JSONEditorSelection | null }) : ContextMenuItem[] | false | undefined
+onRenderContextMenu(items: ContextMenuItem[], context: { mode: 'tree' | 'text' | 'table', modal: boolean, readOnly: boolean, selection: JSONEditorSelection | undefined }) : ContextMenuItem[] | false | undefined
 ```
 
 Callback which can be used to make changes to the context menu items. New items can be added, or existing items can be removed or reorganized. When the function returns `undefined`, the original `items` will be applied and the context menu will be displayed when `readOnly` is `false`. When the function returns `false`, the context menu will never be displayed. The callback is triggered too when the editor is `readOnly`, and in most cases you want to return `false` then.
@@ -583,7 +583,7 @@ A menu item `ContextMenuItem` can be one of the following types:
 #### onSelect
 
 ```ts
-onSelect: (selection: JSONEditorSelection | null) => void
+onSelect: (selection: JSONEditorSelection | undefined) => void
 ```
 
 Callback invoked when the selection is changed. When the selection is removed, the callback is invoked with `undefined` as argument. In `text` mode, a `TextSelection` will be fired. In `tree` and `table` mode, a `JSONSelection` will be fired (which can be `MultiSelection`, `KeySelection`, `ValueSelection`, `InsideSelection`, or `AfterSelection`). Use typeguards like `isTextSelection` and `isValueSelection` to check what type the selection has.
@@ -764,7 +764,7 @@ Refresh rendering of the contents, for example after changing the font size. Thi
 #### validate
 
 ```ts
-JSONEditor.prototype.validate() : ContentErrors | null
+JSONEditor.prototype.validate() : ContentErrors | undefined
 ```
 
 Get all current parse errors and validation errors.
@@ -772,7 +772,7 @@ Get all current parse errors and validation errors.
 #### select
 
 ```ts
-JSONEditor.prototype.select(newSelection: JSONEditorSelection | null)
+JSONEditor.prototype.select(newSelection: JSONEditorSelection | undefined)
 ```
 
 Change the current selection. See also option `selection`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A web-based tool to view, edit, format, transform, and validate JSON.
 
-Try it out: https://jsoneditoronline.org
+Try it out: <https://jsoneditoronline.org>
 
 The library is written with Svelte, but can be used in plain JavaScript too and in any framework (SolidJS, React, Vue, Angular, etc).
 
@@ -41,13 +41,13 @@ npm install vanilla-jsoneditor
 ### Examples
 
 - Svelte:
-  - Playground: https://www.sveltelab.dev/q1l38ztdys4at87
+  - Playground: <https://www.sveltelab.dev/q1l38ztdys4at87>
   - Examples: [/src/routes/examples](/src/routes/examples)
 - Plain JavaScript examples:
-  - Try it out: https://jsbin.com/gatibux/edit?html,output
+  - Try it out: <https://jsbin.com/gatibux/edit?html,output>
   - Examples: [/examples/browser](/examples/browser)
-- React example: https://codesandbox.io/s/svelte-jsoneditor-react-59wxz
-- Vue example: https://codesandbox.io/s/svelte-jsoneditor-vue-toln3w
+- React example: <https://codesandbox.io/s/svelte-jsoneditor-react-59wxz>
+- Vue example: <https://codesandbox.io/s/svelte-jsoneditor-vue-toln3w>
 
 ### Svelte usage
 
@@ -863,13 +863,13 @@ The library exports a set of utility functions. The exact definitions of those f
 
 The TypeScript types (like `Content`, `JSONSelection`, and `JSONPatchOperation`) are defined in the following source file:
 
-https://github.com/josdejong/svelte-jsoneditor/blob/main/src/lib/types.ts
+<https://github.com/josdejong/svelte-jsoneditor/blob/main/src/lib/types.ts>
 
 ## Styling
 
 The editor can be styled using the available CSS variables. A full list with all variables can be found here:
 
-https://github.com/josdejong/svelte-jsoneditor/blob/main/src/lib/themes/defaults.scss
+<https://github.com/josdejong/svelte-jsoneditor/blob/main/src/lib/themes/defaults.scss>
 
 ### Custom theme color
 

--- a/src/lib/actions/onEscape.ts
+++ b/src/lib/actions/onEscape.ts
@@ -21,7 +21,7 @@ function handleKeyDown(event: KeyboardEvent) {
  * This is useful for example when opening a model on top of another modal:
  * you only want the top modal to close on Escape, and not the second modal.
  */
-export function onEscape(element: Element | null, callback: Callback) {
+export function onEscape(element: Element | undefined, callback: Callback) {
   if (isEmpty(callbacks)) {
     window.addEventListener('keydown', handleKeyDown)
   }

--- a/src/lib/assets/svelte-simple-modal/types.d.ts
+++ b/src/lib/assets/svelte-simple-modal/types.d.ts
@@ -39,9 +39,9 @@ declare module 'svelte-simple-modal' {
   ) => TransitionConfig
 
   export interface Options {
-    id: string | null
-    ariaLabel: string | null
-    ariaLabelledBy: string | null
+    id: string | undefined
+    ariaLabel: string | undefined
+    ariaLabelledBy: string | undefined
     closeButton: Component | boolean
     closeOnEsc: boolean
     closeOnOuterClick: boolean
@@ -50,11 +50,11 @@ declare module 'svelte-simple-modal' {
     styleWindow: Styles
     styleContent: Styles
     styleCloseButton: Styles
-    classBg: string | null
-    classWindowWrap: string | null
-    classWindow: string | null
-    classContent: string | null
-    classCloseButton: string | null
+    classBg: string | undefined
+    classWindowWrap: string | undefined
+    classWindow: string | undefined
+    classContent: string | undefined
+    classCloseButton: string | undefined
     transitionBg: TransitionFn
     transitionBgProps: BlurParams
     transitionWindow: TransitionFn
@@ -98,13 +98,13 @@ declare module 'svelte-simple-modal' {
      * Svelte component to be shown as the modal
      * @default null
      */
-    show?: Component | null
+    show?: Component | undefined
 
     /**
      * Element ID assigned to the modal's root DOM element
      * @default null
      */
-    id?: string | null
+    id?: string | undefined
 
     /**
      * Svelte context key to reference the simple modal context
@@ -117,14 +117,14 @@ declare module 'svelte-simple-modal' {
      * @see https://www.w3.org/TR/wai-aria-1.1/#aria-label
      * @default null
      */
-    ariaLabel?: string | null
+    ariaLabel?: string | undefined
 
     /**
      * Element ID holding the accessibility label of the modal
      * @see https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby
      * @default null
      */
-    ariaLabelledBy?: string | null
+    ariaLabelledBy?: string | undefined
 
     /**
      * Whether to show a close button or not
@@ -178,31 +178,31 @@ declare module 'svelte-simple-modal' {
      * Class name for the background element
      * @default null
      */
-    classBg?: string | null
+    classBg?: string | undefined
 
     /**
      * Class name for window wrapper element
      * @default null
      */
-    classWindowWrap?: string | null
+    classWindowWrap?: string | undefined
 
     /**
      * Class name for window element
      * @default null
      */
-    classWindow?: string | null
+    classWindow?: string | undefined
 
     /**
      * Class name for content element
      * @default null
      */
-    classContent?: string | null
+    classContent?: string | undefined
 
     /**
      * Class name for close element
      * @default null
      */
-    classCloseButton?: string | null
+    classCloseButton?: string | undefined
 
     /**
      * Do not apply default styles to the modal

--- a/src/lib/assets/svelte-simple-modal/types.d.ts
+++ b/src/lib/assets/svelte-simple-modal/types.d.ts
@@ -39,9 +39,9 @@ declare module 'svelte-simple-modal' {
   ) => TransitionConfig
 
   export interface Options {
-    id: string | undefined
-    ariaLabel: string | undefined
-    ariaLabelledBy: string | undefined
+    id: string | null
+    ariaLabel: string | null
+    ariaLabelledBy: string | null
     closeButton: Component | boolean
     closeOnEsc: boolean
     closeOnOuterClick: boolean
@@ -50,11 +50,11 @@ declare module 'svelte-simple-modal' {
     styleWindow: Styles
     styleContent: Styles
     styleCloseButton: Styles
-    classBg: string | undefined
-    classWindowWrap: string | undefined
-    classWindow: string | undefined
-    classContent: string | undefined
-    classCloseButton: string | undefined
+    classBg: string | null
+    classWindowWrap: string | null
+    classWindow: string | null
+    classContent: string | null
+    classCloseButton: string | null
     transitionBg: TransitionFn
     transitionBgProps: BlurParams
     transitionWindow: TransitionFn
@@ -98,13 +98,13 @@ declare module 'svelte-simple-modal' {
      * Svelte component to be shown as the modal
      * @default null
      */
-    show?: Component | undefined
+    show?: Component | null
 
     /**
      * Element ID assigned to the modal's root DOM element
      * @default null
      */
-    id?: string | undefined
+    id?: string | null
 
     /**
      * Svelte context key to reference the simple modal context
@@ -117,14 +117,14 @@ declare module 'svelte-simple-modal' {
      * @see https://www.w3.org/TR/wai-aria-1.1/#aria-label
      * @default null
      */
-    ariaLabel?: string | undefined
+    ariaLabel?: string | null
 
     /**
      * Element ID holding the accessibility label of the modal
      * @see https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby
      * @default null
      */
-    ariaLabelledBy?: string | undefined
+    ariaLabelledBy?: string | null
 
     /**
      * Whether to show a close button or not
@@ -178,31 +178,31 @@ declare module 'svelte-simple-modal' {
      * Class name for the background element
      * @default null
      */
-    classBg?: string | undefined
+    classBg?: string | null
 
     /**
      * Class name for window wrapper element
      * @default null
      */
-    classWindowWrap?: string | undefined
+    classWindowWrap?: string | null
 
     /**
      * Class name for window element
      * @default null
      */
-    classWindow?: string | undefined
+    classWindow?: string | null
 
     /**
      * Class name for content element
      * @default null
      */
-    classContent?: string | undefined
+    classContent?: string | null
 
     /**
      * Class name for close element
      * @default null
      */
-    classCloseButton?: string | undefined
+    classCloseButton?: string | null
 
     /**
      * Do not apply default styles to the modal

--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -121,6 +121,11 @@
     }
   }
 
+  // backward compatibility warning since v1.0.0
+  $: if (selection === null) {
+    console.warn('selection is invalid: it is null but should be undefined')
+  }
+
   // We memoize the last parse result for the case when the content is text and very large.
   // In that case parsing takes a few seconds. When the user switches between tree and table mode,
   // without having made a change, we do not want to parse the text again.

--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -64,7 +64,7 @@
   const debug = createDebug('jsoneditor:JSONEditor')
 
   export let content: Content = { text: '' }
-  export let selection: JSONEditorSelection | null = null
+  export let selection: JSONEditorSelection | undefined = undefined
 
   export let readOnly = false
   export let indentation: number | string = 2
@@ -78,7 +78,7 @@
   export let escapeUnicodeCharacters = false
   export let flattenColumns = true
   export let parser: JSONParser = JSON
-  export let validator: Validator | null = null
+  export let validator: Validator | undefined = undefined
   export let validationParser: JSONParser = JSON
   export let pathParser: JSONPathParser = {
     parse: parseJSONPath,
@@ -89,8 +89,8 @@
   export let queryLanguageId: string = queryLanguages[0].id
 
   export let onChangeQueryLanguage: OnChangeQueryLanguage = noop
-  export let onChange: OnChange = null
-  export let onSelect: OnSelect | null = null
+  export let onChange: OnChange | undefined = undefined
+  export let onSelect: OnSelect | undefined = undefined
   export let onRenderValue: OnRenderValue = renderValue
   export let onClassName: OnClassName = () => undefined
   export let onRenderMenu: OnRenderMenu = noop
@@ -107,10 +107,12 @@
   let hasFocus = false
   let refJSONEditorRoot: JSONEditorRoot
   let open: Open // svelte-simple-modal context open(...)
-  let jsoneditorModalState: {
-    component: Component
-    callbacks: Partial<Callbacks>
-  } | null = null
+  let jsoneditorModalState:
+    | {
+        component: Component
+        callbacks: Partial<Callbacks>
+      }
+    | undefined = undefined
 
   $: {
     const contentError = validateContentType(content)
@@ -198,7 +200,7 @@
     return result
   }
 
-  export async function select(newSelection: JSONEditorSelection | null) {
+  export async function select(newSelection: JSONEditorSelection | undefined) {
     selection = newSelection
 
     await tick() // await rerender
@@ -221,7 +223,7 @@
    * Validate the contents of the editor using the configured validator.
    * Returns a parse error or a list with validation warnings
    */
-  export function validate(): ContentErrors | null {
+  export function validate(): ContentErrors | undefined {
     return refJSONEditorRoot.validate()
   }
 
@@ -248,7 +250,7 @@
     await refJSONEditorRoot.scrollTo(path)
   }
 
-  export function findElement(path: JSONPath): Element | null {
+  export function findElement(path: JSONPath): Element | undefined {
     return refJSONEditorRoot.findElement(path)
   }
 
@@ -286,7 +288,7 @@
     }
   }
 
-  function handleSelect(updatedSelection: JSONEditorSelection | null) {
+  function handleSelect(updatedSelection: JSONEditorSelection | undefined) {
     selection = updatedSelection
 
     if (onSelect) {
@@ -424,7 +426,7 @@
 
   function closeJSONEditorModal() {
     jsoneditorModalState?.callbacks?.onClose?.()
-    jsoneditorModalState = null
+    jsoneditorModalState = undefined
   }
 
   $: {

--- a/src/lib/components/controls/SearchBox.svelte
+++ b/src/lib/components/controls/SearchBox.svelte
@@ -229,13 +229,13 @@
 
   // we pass searchText and json as argument to trigger search when these variables change,
   // via various listeners like applyChangedSearchText
-  async function applySearch(showSearch: boolean, text: string, json: unknown) {
+  async function applySearch(showSearch: boolean, text: string, json: unknown): Promise<void> {
     if (!showSearch) {
       if (searchResult) {
         searchResult = undefined
       }
 
-      return
+      return Promise.resolve()
     }
 
     debug('applySearch', { showSearch, text })
@@ -247,7 +247,7 @@
         searchResult = undefined
       }
 
-      return
+      return Promise.resolve()
     }
 
     appliedText = text

--- a/src/lib/components/controls/contextmenu/ContextMenuPointer.svelte
+++ b/src/lib/components/controls/contextmenu/ContextMenuPointer.svelte
@@ -14,7 +14,7 @@
   export let onContextMenu: OnContextMenu
 
   function handleClick(event: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement }) {
-    let buttonElem: Element | null = event.target as HTMLButtonElement
+    let buttonElem: Element | undefined = event.target as HTMLButtonElement
     while (buttonElem && buttonElem.nodeName !== 'BUTTON') {
       buttonElem = buttonElem.parentNode as Element
     }

--- a/src/lib/components/controls/createFocusTracker.ts
+++ b/src/lib/components/controls/createFocusTracker.ts
@@ -5,7 +5,7 @@ const debug = createDebug('jsoneditor:FocusTracker')
 export interface FocusTrackerProps {
   onMount: (callback: () => void) => void
   onDestroy: (callback: () => void) => void
-  getWindow: () => Window | null
+  getWindow: () => Window | undefined
   hasFocus: () => boolean
   onFocus: () => void
   onBlur: () => void

--- a/src/lib/components/controls/navigationBar/NavigationBar.svelte
+++ b/src/lib/components/controls/navigationBar/NavigationBar.svelte
@@ -17,7 +17,7 @@
   const debug = createDebug('jsoneditor:NavigationBar')
 
   export let json: unknown
-  export let selection: JSONSelection | null
+  export let selection: JSONSelection | undefined
   export let onSelect: OnJSONSelect
   export let onError: OnError
   export let pathParser: JSONPathParser

--- a/src/lib/components/modals/JSONEditorModal.svelte
+++ b/src/lib/components/modals/JSONEditorModal.svelte
@@ -97,7 +97,7 @@
   }
 
   function scrollToSelection() {
-    const selection: JSONEditorSelection | undefined = last(stack)?.selection || undefined
+    const selection: JSONEditorSelection | undefined = last(stack)?.selection
     if (isJSONSelection(selection)) {
       refEditor.scrollTo(getFocusPath(selection))
     }

--- a/src/lib/components/modals/JSONEditorModal.svelte
+++ b/src/lib/components/modals/JSONEditorModal.svelte
@@ -51,7 +51,7 @@
   export let escapeUnicodeCharacters: boolean
   export let flattenColumns: boolean
   export let parser: JSONParser
-  export let validator: Validator | null
+  export let validator: Validator | undefined
   export let validationParser: JSONParser
   export let pathParser: JSONPathParser
 
@@ -68,7 +68,7 @@
   interface ModalState {
     mode: Mode
     content: Content
-    selection: JSONEditorSelection | null
+    selection: JSONEditorSelection | undefined
     relativePath: JSONPath
   }
 
@@ -78,7 +78,7 @@
   const rootState: ModalState = {
     mode: determineMode(content),
     content,
-    selection: null,
+    selection: undefined,
     relativePath: path
   }
   let stack: ModalState[] = [rootState]
@@ -97,7 +97,7 @@
   }
 
   function scrollToSelection() {
-    const selection: JSONEditorSelection | null = last(stack)?.selection || null
+    const selection: JSONEditorSelection | undefined = last(stack)?.selection || undefined
     if (isJSONSelection(selection)) {
       refEditor.scrollTo(getFocusPath(selection))
     }
@@ -180,7 +180,7 @@
     stack = [...initial(stack), updatedState]
   }
 
-  function handleChangeSelection(newSelection: JSONEditorSelection | null) {
+  function handleChangeSelection(newSelection: JSONEditorSelection | undefined) {
     debug('handleChangeSelection', newSelection)
 
     const updatedState = {
@@ -213,7 +213,7 @@
     const nestedModalState = {
       mode: determineMode(content),
       content,
-      selection: null,
+      selection: undefined,
       relativePath: path
     }
     stack = [...stack, nestedModalState]

--- a/src/lib/components/modals/TransformModal.svelte
+++ b/src/lib/components/modals/TransformModal.svelte
@@ -286,7 +286,7 @@
             {#if showOriginal}
               <TreeMode
                 externalContent={selectedContent}
-                externalSelection={null}
+                externalSelection={undefined}
                 readOnly={true}
                 mainMenuBar={false}
                 navigationBar={false}
@@ -308,7 +308,7 @@
                 onTransformModal={noop}
                 onJSONEditorModal={noop}
                 {onClassName}
-                validator={null}
+                validator={undefined}
                 {validationParser}
                 {pathParser}
               />
@@ -321,7 +321,7 @@
             {#if !previewError}
               <TreeMode
                 externalContent={previewContent}
-                externalSelection={null}
+                externalSelection={undefined}
                 readOnly={true}
                 mainMenuBar={false}
                 navigationBar={false}
@@ -343,7 +343,7 @@
                 onTransformModal={noop}
                 onJSONEditorModal={noop}
                 {onClassName}
-                validator={null}
+                validator={undefined}
                 {validationParser}
                 {pathParser}
               />

--- a/src/lib/components/modals/TransformWizard.svelte
+++ b/src/lib/components/modals/TransformWizard.svelte
@@ -34,22 +34,22 @@
   ]
 
   // TODO: the binding with the select boxes is very cumbersome. Can we simplify this?
-  let filterPath = queryOptions?.filter?.path ? pathToOption(queryOptions.filter.path) : null
+  let filterPath = queryOptions?.filter?.path ? pathToOption(queryOptions.filter.path) : undefined
   let filterRelation = queryOptions?.filter?.relation
     ? filterRelationOptions.find((option) => option.value === queryOptions.filter?.relation)
-    : null
+    : undefined
   let filterValue = queryOptions?.filter?.value || ''
-  let sortPath = queryOptions?.sort?.path ? pathToOption(queryOptions.sort.path) : null
+  let sortPath = queryOptions?.sort?.path ? pathToOption(queryOptions.sort.path) : undefined
   let sortDirection = queryOptions?.sort?.direction
     ? sortDirectionOptions.find((option) => option.value === queryOptions.sort?.direction)
-    : null
+    : undefined
 
   $: projectionPaths =
     queryOptions?.projection?.paths && projectionOptions
       ? (queryOptions.projection.paths
           .map((path) => projectionOptions.find((option) => isEqual(option.value, path)))
           .filter((option) => !!option) as PathOption[])
-      : null
+      : undefined
 
   function changeFilterPath(path: JSONPath | undefined) {
     if (!isEqual(queryOptions?.filter?.path, path)) {

--- a/src/lib/components/modals/repair/JSONRepairComponent.svelte
+++ b/src/lib/components/modals/repair/JSONRepairComponent.svelte
@@ -12,7 +12,7 @@
   import Message from '../../controls/Message.svelte'
   import { normalizeJsonParseError } from '$lib/utils/jsonUtils.js'
   import Menu from '../../controls/Menu.svelte'
-  import type { MenuItem } from '$lib/types.js'
+  import type { MenuItem, ParseError } from '$lib/types.js'
 
   export let text = ''
   export let readOnly = false
@@ -31,10 +31,10 @@
 
   $: debug('error', error)
 
-  function getErrorMessage(jsonText: string) {
+  function getErrorMessage(jsonText: string): ParseError | undefined {
     try {
       onParse(jsonText)
-      return null
+      return undefined
     } catch (err) {
       return normalizeJsonParseError(jsonText, (err as Error).message)
     }
@@ -51,7 +51,7 @@
 
   function goToError() {
     if (domTextArea && error) {
-      const position = error.position != null ? error.position : 0
+      const position = error.position !== undefined ? error.position : 0
       domTextArea.setSelectionRange(position, position)
       domTextArea.focus()
     }

--- a/src/lib/components/modals/repair/JSONRepairComponent.svelte
+++ b/src/lib/components/modals/repair/JSONRepairComponent.svelte
@@ -18,7 +18,7 @@
   export let readOnly = false
   export let onParse: (text: string) => void
   export let onRepair: (text: string) => string
-  export let onChange: ((updatedText: string) => void) | null = null
+  export let onChange: ((updatedText: string) => void) | undefined = undefined
   export let onApply: (repairedText: string) => void
   export let onCancel: () => void
 

--- a/src/lib/components/modes/JSONEditorRoot.svelte
+++ b/src/lib/components/modes/JSONEditorRoot.svelte
@@ -37,7 +37,7 @@
   import { cloneDeep } from 'lodash-es'
 
   export let content: Content
-  export let selection: JSONEditorSelection | null
+  export let selection: JSONEditorSelection | undefined
 
   export let readOnly: boolean
   export let indentation: number | string
@@ -52,7 +52,7 @@
   export let flattenColumns: boolean
   export let parser: JSONParser
   export let parseMemoizeOne: JSONParser['parse']
-  export let validator: Validator | null
+  export let validator: Validator | undefined
   export let validationParser: JSONParser
   export let pathParser: JSONPathParser
   export let insideModal: boolean
@@ -177,7 +177,7 @@
    * Validate the contents of the editor using the configured validator.
    * Returns a parse error or a list with validation warnings
    */
-  export function validate(): ContentErrors | null {
+  export function validate(): ContentErrors | undefined {
     if (refTextMode) {
       return refTextMode.validate()
     } else if (refTreeMode) {
@@ -219,7 +219,7 @@
     }
   }
 
-  export function findElement(path: JSONPath): Element | null {
+  export function findElement(path: JSONPath): Element | undefined {
     if (refTreeMode) {
       return refTreeMode.findElement(path)
     } else if (refTableMode) {

--- a/src/lib/components/modes/tablemode/ColumnHeader.svelte
+++ b/src/lib/components/modes/tablemode/ColumnHeader.svelte
@@ -12,7 +12,7 @@
   import { truncate } from '$lib/utils/stringUtils.js'
 
   export let path: JSONPath
-  export let sortedColumn: SortedColumn | null
+  export let sortedColumn: SortedColumn | undefined
   export let readOnly: boolean
   export let onSort: (sortedColumn: SortedColumn) => void
 

--- a/src/lib/components/modes/tablemode/JSONValue.svelte
+++ b/src/lib/components/modes/tablemode/JSONValue.svelte
@@ -16,7 +16,7 @@
   export let value: unknown
   export let context: JSONEditorContext
   export let enforceString: boolean
-  export let selection: JSONSelection | null
+  export let selection: JSONSelection | undefined
   export let searchResultItems: SearchResultItem[] | undefined
 
   function handlePatch(operations: JSONPatchDocument, afterPatch?: AfterPatchCallback) {

--- a/src/lib/components/modes/tablemode/TableMode.svelte
+++ b/src/lib/components/modes/tablemode/TableMode.svelte
@@ -448,7 +448,7 @@
     if (!isEqual(selection, externalSelection)) {
       debug('applyExternalSelection', externalSelection)
 
-      if (isJSONSelection(externalSelection) || externalSelection === null) {
+      if (isJSONSelection(externalSelection) || externalSelection === undefined) {
         updateSelection(externalSelection)
       }
     }

--- a/src/lib/components/modes/tablemode/TableMode.svelte
+++ b/src/lib/components/modes/tablemode/TableMode.svelte
@@ -312,14 +312,12 @@
     updatedSelection:
       | JSONSelection
       | undefined
-      | ((selection: JSONSelection | undefined) => JSONSelection | undefined | void | undefined)
+      | ((selection: JSONSelection | undefined) => JSONSelection | undefined)
   ) {
     debug('updateSelection', updatedSelection)
 
     const appliedSelection =
-      typeof updatedSelection === 'function'
-        ? updatedSelection(selection) || undefined
-        : updatedSelection
+      typeof updatedSelection === 'function' ? updatedSelection(selection) : updatedSelection
 
     if (!isEqual(appliedSelection, selection)) {
       selection = appliedSelection
@@ -1004,8 +1002,6 @@
         }
       }
     }
-
-    return false
   }
 
   function handleContextMenuFromTableMenu(event: MouseEvent) {
@@ -1080,7 +1076,7 @@
     const { path, contents } = pastedJson
 
     // exit edit mode
-    const refEditableDiv = refContents?.querySelector('.jse-editable-div') || undefined
+    const refEditableDiv = refContents?.querySelector('.jse-editable-div') ?? undefined
     if (isEditableDivRef(refEditableDiv)) {
       refEditableDiv.cancel()
     }

--- a/src/lib/components/modes/tablemode/TableMode.svelte
+++ b/src/lib/components/modes/tablemode/TableMode.svelte
@@ -164,14 +164,14 @@
 
   export let readOnly: boolean
   export let externalContent: Content
-  export let externalSelection: JSONEditorSelection | null
+  export let externalSelection: JSONEditorSelection | undefined
   export let mainMenuBar: boolean
   export let escapeControlCharacters: boolean
   export let escapeUnicodeCharacters: boolean
   export let flattenColumns: boolean
   export let parser: JSONParser
   export let parseMemoizeOne: JSONParser['parse']
-  export let validator: Validator | null
+  export let validator: Validator | undefined
   export let validationParser: JSONParser
   export let indentation: number | string
   export let onChange: OnChange
@@ -248,7 +248,7 @@
   }
 
   async function handleFocusSearch(path: JSONPath) {
-    selection = null // navigation path of current selection would be confusing
+    selection = undefined // navigation path of current selection would be confusing
     await scrollTo(path)
   }
 
@@ -311,14 +311,14 @@
   function updateSelection(
     updatedSelection:
       | JSONSelection
-      | null
-      | ((selection: JSONSelection | null) => JSONSelection | null | void | undefined)
+      | undefined
+      | ((selection: JSONSelection | undefined) => JSONSelection | undefined | void | undefined)
   ) {
     debug('updateSelection', updatedSelection)
 
     const appliedSelection =
       typeof updatedSelection === 'function'
-        ? updatedSelection(selection) || null
+        ? updatedSelection(selection) || undefined
         : updatedSelection
 
     if (!isEqual(appliedSelection, selection)) {
@@ -337,13 +337,13 @@
     }
 
     debug('clearing selection: path does not exist anymore', selection)
-    selection = null // TODO: try find the closest cell that still exists (similar to getInitialSelection)
+    selection = undefined // TODO: try find the closest cell that still exists (similar to getInitialSelection)
   }
 
   let documentState: DocumentState | undefined =
     json !== undefined ? createDocumentState({ json }) : undefined
-  let selection: JSONSelection | null = null
-  let sortedColumn: SortedColumn | null = null
+  let selection: JSONSelection | undefined = undefined
+  let sortedColumn: SortedColumn | undefined = undefined
   let textIsRepaired = false
 
   function onSortByHeader(newSortedColumn: SortedColumn) {
@@ -441,12 +441,12 @@
     clearSelectionWhenNotExisting(json)
 
     // reset the sorting order (we don't know...)
-    sortedColumn = null
+    sortedColumn = undefined
 
     addHistoryItem(previousState)
   }
 
-  function applyExternalSelection(externalSelection: JSONEditorSelection | null) {
+  function applyExternalSelection(externalSelection: JSONEditorSelection | undefined) {
     if (!isEqual(selection, externalSelection)) {
       debug('applyExternalSelection', externalSelection)
 
@@ -460,9 +460,9 @@
     json: unknown | undefined
     text: string | undefined
     documentState: DocumentState | undefined
-    selection: JSONSelection | null
+    selection: JSONSelection | undefined
     textIsRepaired: boolean
-    sortedColumn: SortedColumn | null
+    sortedColumn: SortedColumn | undefined
   }
 
   function addHistoryItem(previous: PreviousState) {
@@ -505,7 +505,7 @@
 
   function updateValidationErrors(
     json: unknown,
-    validator: Validator | null,
+    validator: Validator | undefined,
     parser: JSONParser,
     validationParser: JSONParser
   ) {
@@ -533,7 +533,7 @@
     )
   }
 
-  export function validate(): ContentErrors | null {
+  export function validate(): ContentErrors | undefined {
     debug('validate')
 
     if (parseError) {
@@ -546,7 +546,7 @@
     // make sure the validation results are up-to-date
     // normally, they are only updated on the next tick after the json is changed
     updateValidationErrors(json, validator, parser, validationParser)
-    return !isEmpty(validationErrors) ? { validationErrors } : null
+    return !isEmpty(validationErrors) ? { validationErrors } : undefined
   }
 
   export function patch(
@@ -638,7 +638,7 @@
     return patchResult
   }
 
-  function emitOnChange(previousContent: Content, patchResult: JSONPatchResult | null) {
+  function emitOnChange(previousContent: Content, patchResult: JSONPatchResult | undefined) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     if (previousContent.json === undefined && previousContent?.text === undefined) {
@@ -726,14 +726,14 @@
     }
   }
 
-  function createDefaultSelection(): JSONSelection | null {
+  function createDefaultSelection(): JSONSelection | undefined {
     if (isJSONArray(json) && !isEmpty(json) && !isEmpty(columns)) {
       // Select the first row, first column
       const path = ['0', ...columns[0]]
 
       return createValueSelection(path, false)
     } else {
-      return null
+      return undefined
     }
   }
 
@@ -759,7 +759,7 @@
       // we could work out a patchResult, or use patch(), but only when the previous and new
       // contents are both json and not text. We go for simplicity and consistency here and
       // do _not_ return a patchResult ever.
-      const patchResult = null
+      const patchResult = undefined
 
       emitOnChange(previousContent, patchResult)
     }
@@ -880,14 +880,14 @@
    * Find the DOM element of a given path.
    * Note that the path can only be found when the node is expanded.
    */
-  export function findElement(path: JSONPath): Element | null {
+  export function findElement(path: JSONPath): Element | undefined {
     const column = columns.find((c) => pathStartsWith(path.slice(1), c))
 
     const resolvedPath = column ? path.slice(0, 1).concat(column) : path
 
-    return refContents
-      ? refContents.querySelector(`td[data-path="${encodeDataPath(resolvedPath)}"]`)
-      : null
+    return (
+      refContents?.querySelector(`td[data-path="${encodeDataPath(resolvedPath)}"]`) ?? undefined
+    )
   }
 
   function openContextMenu({
@@ -1080,7 +1080,7 @@
     const { path, contents } = pastedJson
 
     // exit edit mode
-    const refEditableDiv = refContents?.querySelector('.jse-editable-div') || null
+    const refEditableDiv = refContents?.querySelector('.jse-editable-div') || undefined
     if (isEditableDivRef(refEditableDiv)) {
       refEditableDiv.cancel()
     }
@@ -1328,7 +1328,7 @@
 
     if (combo === 'Escape' && selection) {
       event.preventDefault()
-      updateSelection(null)
+      updateSelection(undefined)
     }
 
     if (combo === 'Ctrl+F') {
@@ -1394,7 +1394,7 @@
     json = callback?.json !== undefined ? callback.json : updatedJson
     documentState = callback?.state !== undefined ? callback.state : updatedState
     selection = callback?.selection !== undefined ? callback.selection : selection
-    sortedColumn = null // we can't know whether the new json is still sorted or not
+    sortedColumn = undefined // we can't know whether the new json is still sorted or not
     text = undefined
     textIsRepaired = false
     parseError = undefined
@@ -1407,7 +1407,7 @@
     // we could work out a patchResult, or use patch(), but only when the previous and new
     // contents are both json and not text. We go for simplicity and consistency here and
     // do _not_ return a patchResult ever.
-    const patchResult = null
+    const patchResult = undefined
 
     emitOnChange(previousContent, patchResult)
   }
@@ -1469,7 +1469,7 @@
     addHistoryItem(previousState)
 
     // no JSON patch actions available in text mode
-    const patchResult = null
+    const patchResult = undefined
 
     emitOnChange(previousContent, patchResult)
   }
@@ -1656,7 +1656,7 @@
             redo: item.undo.patch,
             undo: item.redo.patch
           }
-        : null
+        : undefined
 
     emitOnChange(previousContent, patchResult)
 
@@ -1700,7 +1700,7 @@
             redo: item.redo.patch,
             undo: item.undo.patch
           }
-        : null
+        : undefined
 
     emitOnChange(previousContent, patchResult)
 
@@ -1873,7 +1873,7 @@
                         {path}
                         value={value !== undefined ? value : ''}
                         enforceString={getEnforceString(json, documentState, path, context.parser)}
-                        selection={isSelected ? selection : null}
+                        selection={isSelected ? selection : undefined}
                         searchResultItems={searchResultItemsByCell}
                         {context}
                       />{/if}{#if !readOnly && isSelected && !isEditingSelection(selection)}

--- a/src/lib/components/modes/tablemode/contextmenu/createTableContextMenuItems.ts
+++ b/src/lib/components/modes/tablemode/contextmenu/createTableContextMenuItems.ts
@@ -60,13 +60,14 @@ export default function ({
     hasJson &&
     (isMultiSelection(selection) || isKeySelection(selection) || isValueSelection(selection))
 
-  const canEditValue = !readOnly && hasJson && selection != null && singleItemSelected(selection)
+  const canEditValue =
+    !readOnly && hasJson && selection !== undefined && singleItemSelected(selection)
   const canEnforceString = canEditValue && !isObjectOrArray(focusValue)
 
   const canCut = !readOnly && hasSelectionContents
 
   const enforceString =
-    selection != null
+    selection !== undefined
       ? getEnforceString(json, documentState, getFocusPath(selection), parser)
       : false
 

--- a/src/lib/components/modes/tablemode/contextmenu/createTableContextMenuItems.ts
+++ b/src/lib/components/modes/tablemode/contextmenu/createTableContextMenuItems.ts
@@ -36,7 +36,7 @@ export default function ({
 }: {
   json: unknown | undefined
   documentState: DocumentState | undefined
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   readOnly: boolean
   parser: JSONParser
   onEditValue: () => void

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -121,12 +121,12 @@
   export let statusBar: boolean
   export let askToFormat: boolean
   export let externalContent: Content
-  export let externalSelection: JSONEditorSelection | null
+  export let externalSelection: JSONEditorSelection | undefined
   export let indentation: number | string
   export let tabSize: number
   export let escapeUnicodeCharacters: boolean
   export let parser: JSONParser
-  export let validator: Validator | null
+  export let validator: Validator | undefined
   export let validationParser: JSONParser
   export let onChange: OnChange
   export let onChangeMode: OnChangeMode
@@ -334,7 +334,7 @@
       setCodeMirrorContent(updatedContent, true, false)
 
       jsonStatus = JSON_STATUS_VALID
-      jsonParseError = null
+      jsonParseError = undefined
     } catch (err) {
       onError(err as Error)
     }
@@ -472,7 +472,7 @@
     debug('select validation error', validationError)
 
     const { from, to } = toRichValidationError(validationError)
-    if (from === null || to === null) {
+    if (from === undefined || to === undefined) {
       return
     }
 
@@ -635,7 +635,7 @@
       : false
   }
 
-  function isValidSelection(selection: JSONEditorSelection | null, text: string): boolean {
+  function isValidSelection(selection: JSONEditorSelection | undefined, text: string): boolean {
     if (!isTextSelection(selection)) {
       return false
     }
@@ -678,7 +678,7 @@
                 apply: () => handleRepair()
               }
             ]
-          : null
+          : undefined
     }
   }
 
@@ -725,7 +725,7 @@
     }
   }
 
-  function applyExternalSelection(externalSelection: JSONEditorSelection | null) {
+  function applyExternalSelection(externalSelection: JSONEditorSelection | undefined) {
     if (!isTextSelection(externalSelection)) {
       return
     }
@@ -740,7 +740,7 @@
   }
 
   function toCodeMirrorSelection(
-    selection: JSONEditorSelection | null
+    selection: JSONEditorSelection | undefined
   ): EditorSelection | undefined {
     return isTextSelection(selection) ? EditorSelection.fromJSON(selection) : undefined
   }
@@ -799,7 +799,7 @@
     tick().then(emitOnSelect)
   }
 
-  function updateLinter(validator: Validator | null) {
+  function updateLinter(validator: Validator | undefined) {
     debug('updateLinter', validator)
 
     if (!codeMirrorView) {
@@ -892,7 +892,7 @@
     if (onChange) {
       onChange(content, previousContent, {
         contentErrors: validate(),
-        patchResult: null
+        patchResult: undefined
       })
     }
   }
@@ -911,7 +911,7 @@
 
   let jsonStatus = JSON_STATUS_VALID
 
-  let jsonParseError: ParseError | null = null
+  let jsonParseError: ParseError | undefined
 
   function linterCallback(): Diagnostic[] {
     if (disableTextEditor(text, acceptTooLarge)) {
@@ -933,7 +933,7 @@
     return []
   }
 
-  export function validate(): ContentErrors | null {
+  export function validate(): ContentErrors | undefined {
     debug('validate:start')
 
     flush()
@@ -951,7 +951,7 @@
       validationErrors = []
     } else {
       jsonStatus = JSON_STATUS_VALID
-      jsonParseError = null
+      jsonParseError = undefined
       validationErrors = contentErrors?.validationErrors || []
     }
 

--- a/src/lib/components/modes/treemode/CollapsedItems.svelte
+++ b/src/lib/components/modes/treemode/CollapsedItems.svelte
@@ -10,7 +10,7 @@
   export let sectionIndex: number
   export let total: number
   export let path: JSONPath
-  export let selection: JSONSelection | null
+  export let selection: JSONSelection | undefined
   export let onExpandSection: (path: JSONPath, section: Section) => void
   export let context: JSONEditorContext
 

--- a/src/lib/components/modes/treemode/JSONKey.svelte
+++ b/src/lib/components/modes/treemode/JSONKey.svelte
@@ -19,7 +19,7 @@
 
   export let pointer: JSONPointer
   export let key: string
-  export let selection: JSONSelection | null
+  export let selection: JSONSelection | undefined
   export let searchResultItems: ExtendedSearchResultItem[] | undefined
   export let onUpdateKey: (oldKey: string, newKey: string) => string
 

--- a/src/lib/components/modes/treemode/JSONNode.svelte
+++ b/src/lib/components/modes/treemode/JSONNode.svelte
@@ -253,7 +253,7 @@
           context.onSelect(createMultiSelection(path, path))
         }
       } else if (json !== undefined) {
-        context.onSelect(fromSelectionType(json, anchorType, path))
+        context.onSelect(fromSelectionType(anchorType, path))
       }
     }
   }
@@ -433,7 +433,7 @@
           const selectionType = getSelectionTypeFromTarget(event.target as Element)
           const path = getDataPathFromTarget(event.target as Element)
           if (path) {
-            context.onSelect(fromSelectionType(json, selectionType, path))
+            context.onSelect(fromSelectionType(selectionType, path))
           }
         }
       }

--- a/src/lib/components/modes/treemode/JSONNode.svelte
+++ b/src/lib/components/modes/treemode/JSONNode.svelte
@@ -263,7 +263,7 @@
       event.preventDefault()
       event.stopPropagation()
 
-      if (singleton.selectionFocus == null) {
+      if (singleton.selectionFocus === undefined) {
         // First move event, no selection yet.
         // Clear the default selection of the browser
         if (window.getSelection) {
@@ -460,7 +460,7 @@
     function addHeight(prop: string) {
       const itemPath = path.concat(prop)
       const element = context.findElement(itemPath)
-      if (element != null) {
+      if (element !== undefined) {
         items.push({
           path: itemPath,
           height: element.clientHeight

--- a/src/lib/components/modes/treemode/JSONNode.svelte
+++ b/src/lib/components/modes/treemode/JSONNode.svelte
@@ -83,7 +83,7 @@
   export let state: DocumentState | undefined
   export let validationErrors: ValidationErrors | undefined
   export let searchResults: SearchResults | undefined
-  export let selection: JSONSelection | null
+  export let selection: JSONSelection | undefined
   export let context: TreeModeContext
   export let onDragSelectionStart: (
     event: MouseEvent & { currentTarget: EventTarget & HTMLDivElement }
@@ -454,7 +454,7 @@
   function getVisibleItemsWithHeights(
     selection: JSONSelection,
     visibleSections: VisibleSection[]
-  ): RenderedItem[] | null {
+  ): RenderedItem[] | undefined {
     const items: RenderedItem[] = []
 
     function addHeight(prop: string) {
@@ -471,7 +471,7 @@
     if (Array.isArray(value)) {
       const json = context.getJson()
       if (json === undefined) {
-        return null
+        return undefined
       }
       const startPath = getStartPath(json, selection)
       const endPath = getEndPath(json, selection)
@@ -487,7 +487,7 @@
       })
 
       if (!currentSection) {
-        return null
+        return undefined
       }
 
       const { start, end } = currentSection
@@ -860,7 +860,7 @@
           {path}
           {value}
           {enforceString}
-          selection={isNodeSelected ? selection : null}
+          selection={isNodeSelected ? selection : undefined}
           searchResultItems={filterValueSearchResults(searchResults)}
           {context}
         />

--- a/src/lib/components/modes/treemode/JSONValue.svelte
+++ b/src/lib/components/modes/treemode/JSONValue.svelte
@@ -10,7 +10,7 @@
   export let value: unknown
   export let context: JSONEditorContext
   export let enforceString: boolean
-  export let selection: JSONSelection | null
+  export let selection: JSONSelection | undefined
   export let searchResultItems: SearchResultItem[] | undefined
 
   $: isEditing = isValueSelection(selection) && isEditingSelection(selection)

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -1848,9 +1848,7 @@
       if (isEditingSelection(selection)) {
         debug('click outside the editor, stop edit mode')
         updateSelection((selection) => {
-          if (isKeySelection(selection)) {
-            return { ...selection, edit: false }
-          } else if (isValueSelection(selection)) {
+          if (isKeySelection(selection) || isValueSelection(selection)) {
             return { ...selection, edit: false }
           } else {
             return selection

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -302,7 +302,6 @@
 
   async function handleFocusSearch(path: JSONPath) {
     documentState = expandPath(json, documentState, path)
-    null // navigation path of current selection would be confusing
     await scrollTo(path)
   }
 
@@ -504,7 +503,7 @@
 
     debug('applyExternalSelection', externalSelection)
 
-    if (isJSONSelection(externalSelection) || externalSelection === null) {
+    if (isJSONSelection(externalSelection) || externalSelection === undefined) {
       updateSelection(externalSelection)
     }
   }

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -243,14 +243,12 @@
     updatedSelection:
       | JSONSelection
       | undefined
-      | ((selection: JSONSelection | undefined) => JSONSelection | undefined | void)
+      | ((selection: JSONSelection | undefined) => JSONSelection | undefined)
   ) {
     debug('updateSelection', updatedSelection)
 
     const appliedSelection =
-      typeof updatedSelection === 'function'
-        ? updatedSelection(selection) || undefined
-        : updatedSelection
+      typeof updatedSelection === 'function' ? updatedSelection(selection) : updatedSelection
 
     if (!isEqual(appliedSelection, selection)) {
       selection = appliedSelection
@@ -849,6 +847,8 @@
           state: expandRecursive(patchedJson, patchedState, path)
         }
       }
+
+      return undefined
     })
   }
 
@@ -1222,7 +1222,7 @@
    * Note that the path can only be found when the node is expanded.
    */
   export function findElement(path: JSONPath): Element | undefined {
-    return refContents?.querySelector(`div[data-path="${encodeDataPath(path)}"]`) || undefined
+    return refContents?.querySelector(`div[data-path="${encodeDataPath(path)}"]`) ?? undefined
   }
 
   /**
@@ -1765,8 +1765,6 @@
         }
       }
     }
-
-    return false
   }
 
   function handleContextMenuFromTreeMenu(event: MouseEvent) {
@@ -1789,7 +1787,7 @@
     pastedJson = undefined
 
     // exit edit mode
-    const refEditableDiv = refContents?.querySelector('.jse-editable-div') || undefined
+    const refEditableDiv = refContents?.querySelector('.jse-editable-div') ?? undefined
     if (isEditableDivRef(refEditableDiv)) {
       refEditableDiv.cancel()
     }

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -183,14 +183,14 @@
 
   export let readOnly: boolean
   export let externalContent: Content
-  export let externalSelection: JSONEditorSelection | null
+  export let externalSelection: JSONEditorSelection | undefined
   export let mainMenuBar: boolean
   export let navigationBar: boolean
   export let escapeControlCharacters: boolean
   export let escapeUnicodeCharacters: boolean
   export let parser: JSONParser
   export let parseMemoizeOne: JSONParser['parse']
-  export let validator: Validator | null
+  export let validator: Validator | undefined
   export let validationParser: JSONParser
   export let pathParser: JSONPathParser
   export let indentation: number | string
@@ -237,19 +237,19 @@
 
   let documentStateInitialized = false
   let documentState: DocumentState | undefined = createDocumentState({ json })
-  let selection: JSONSelection | null
+  let selection: JSONSelection | undefined
 
   function updateSelection(
     updatedSelection:
       | JSONSelection
-      | null
-      | ((selection: JSONSelection | null) => JSONSelection | null | undefined | void)
+      | undefined
+      | ((selection: JSONSelection | undefined) => JSONSelection | undefined | void)
   ) {
     debug('updateSelection', updatedSelection)
 
     const appliedSelection =
       typeof updatedSelection === 'function'
-        ? updatedSelection(selection) || null
+        ? updatedSelection(selection) || undefined
         : updatedSelection
 
     if (!isEqual(appliedSelection, selection)) {
@@ -354,7 +354,7 @@
 
   function updateValidationErrors(
     json: unknown,
-    validator: Validator | null,
+    validator: Validator | undefined,
     parser: JSONParser,
     validationParser: JSONParser
   ) {
@@ -383,7 +383,7 @@
     )
   }
 
-  export function validate(): ContentErrors | null {
+  export function validate(): ContentErrors | undefined {
     debug('validate')
 
     if (parseError) {
@@ -396,7 +396,7 @@
     // make sure the validation results are up-to-date
     // normally, they are only updated on the next tick after the json is changed
     updateValidationErrors(json, validator, parser, validationParser)
-    return !isEmpty(validationErrorList) ? { validationErrors: validationErrorList } : null
+    return !isEmpty(validationErrorList) ? { validationErrors: validationErrorList } : undefined
   }
 
   export function getJson() {
@@ -407,7 +407,7 @@
     return documentState
   }
 
-  function getSelection(): JSONSelection | null {
+  function getSelection(): JSONSelection | undefined {
     return selection
   }
 
@@ -499,7 +499,7 @@
     addHistoryItem(previousState)
   }
 
-  function applyExternalSelection(externalSelection: JSONEditorSelection | null) {
+  function applyExternalSelection(externalSelection: JSONEditorSelection | undefined) {
     if (isEqual(selection, externalSelection)) {
       return
     }
@@ -535,7 +535,7 @@
     json: unknown | undefined
     text: string | undefined
     documentState: DocumentState | undefined
-    selection: JSONSelection | null
+    selection: JSONSelection | undefined
     textIsRepaired: boolean
   }
 
@@ -555,7 +555,7 @@
         documentState: previous.documentState,
         textIsRepaired: previous.textIsRepaired,
         selection: removeEditModeFromSelection(previous.selection),
-        sortedColumn: null
+        sortedColumn: undefined
       },
       redo: {
         patch: canPatch ? [{ op: 'replace', path: '', value: json }] : undefined,
@@ -564,7 +564,7 @@
         documentState,
         textIsRepaired,
         selection: removeEditModeFromSelection(selection),
-        sortedColumn: null
+        sortedColumn: undefined
       }
     })
   }
@@ -592,7 +592,7 @@
       documentState,
       selection: removeEditModeFromSelection(selection),
       textIsRepaired,
-      sortedColumn: null
+      sortedColumn: undefined
     }
 
     // execute the patch operations
@@ -632,7 +632,7 @@
         text,
         documentState,
         selection: removeEditModeFromSelection(selection),
-        sortedColumn: null,
+        sortedColumn: undefined,
         textIsRepaired
       }
     })
@@ -1006,7 +1006,7 @@
             redo: item.undo.patch,
             undo: item.redo.patch
           }
-        : null
+        : undefined
 
     emitOnChange(previousContent, patchResult)
 
@@ -1049,7 +1049,7 @@
             redo: item.redo.patch,
             undo: item.undo.patch
           }
-        : null
+        : undefined
 
     emitOnChange(previousContent, patchResult)
 
@@ -1221,10 +1221,8 @@
    * Find the DOM element of a given path.
    * Note that the path can only be found when the node is expanded.
    */
-  export function findElement(path: JSONPath): Element | null {
-    return refContents
-      ? refContents.querySelector(`div[data-path="${encodeDataPath(path)}"]`)
-      : null
+  export function findElement(path: JSONPath): Element | undefined {
+    return refContents?.querySelector(`div[data-path="${encodeDataPath(path)}"]`) || undefined
   }
 
   /**
@@ -1262,7 +1260,7 @@
     }
   }
 
-  function emitOnChange(previousContent: Content, patchResult: JSONPatchResult | null) {
+  function emitOnChange(previousContent: Content, patchResult: JSONPatchResult | undefined) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     if (previousContent.json === undefined && previousContent?.text === undefined) {
@@ -1332,7 +1330,7 @@
     // we could work out a patchResult, or use patch(), but only when the previous and new
     // contents are both json and not text. We go for simplicity and consistency here and
     // do _not_ return a patchResult ever.
-    const patchResult = null
+    const patchResult = undefined
 
     emitOnChange(previousContent, patchResult)
   }
@@ -1393,7 +1391,7 @@
     addHistoryItem(previousState)
 
     // no JSON patch actions available in text mode
-    const patchResult = null
+    const patchResult = undefined
 
     emitOnChange(previousContent, patchResult)
   }
@@ -1420,7 +1418,7 @@
         // check whether the selection is still visible and not collapsed
         if (isSelectionInsidePath(selection, path)) {
           // remove selection when not visible anymore
-          updateSelection(null)
+          updateSelection(undefined)
         }
       }
     }
@@ -1611,7 +1609,7 @@
 
     if (combo === 'Escape' && selection) {
       event.preventDefault()
-      updateSelection(null)
+      updateSelection(undefined)
     }
 
     if (combo === 'Ctrl+F') {
@@ -1791,7 +1789,7 @@
     pastedJson = undefined
 
     // exit edit mode
-    const refEditableDiv = refContents?.querySelector('.jse-editable-div') || null
+    const refEditableDiv = refContents?.querySelector('.jse-editable-div') || undefined
     if (isEditableDivRef(refEditableDiv)) {
       refEditableDiv.cancel()
     }
@@ -1874,8 +1872,8 @@
     }
   }
 
-  function findNextInside(path: JSONPath): JSONSelection | null {
-    return getSelectionNextInside(json, documentState, selection, path)
+  function findNextInside(path: JSONPath): JSONSelection | undefined {
+    return getSelectionNextInside(json, documentState, path)
   }
 
   $: autoScrollHandler = refContents ? createAutoScrollHandler(refContents) : undefined

--- a/src/lib/components/modes/treemode/contextmenu/createTreeContextMenuItems.ts
+++ b/src/lib/components/modes/treemode/contextmenu/createTreeContextMenuItems.ts
@@ -101,7 +101,8 @@ export default function ({
   const canEditKey =
     !readOnly && hasJson && singleItemSelected(selection) && !rootSelected && !Array.isArray(parent)
 
-  const canEditValue = !readOnly && hasJson && selection != null && singleItemSelected(selection)
+  const canEditValue =
+    !readOnly && hasJson && selection !== undefined && singleItemSelected(selection)
   const canEnforceString = canEditValue && !isObjectOrArray(focusValue)
 
   const canCut = !readOnly && hasSelectionContents
@@ -111,7 +112,7 @@ export default function ({
   const canExtract =
     !readOnly &&
     hasJson &&
-    selection != null &&
+    selection !== undefined &&
     (isMultiSelection(selection) || isValueSelection(selection)) &&
     !rootSelected // must not be root
 
@@ -130,7 +131,7 @@ export default function ({
     !readOnly && (convertMode ? canConvert(selection) && isObjectOrArray(focusValue) : hasSelection)
 
   const enforceString =
-    selection != null
+    selection !== undefined
       ? getEnforceString(json, documentState, getFocusPath(selection), parser)
       : false
 

--- a/src/lib/components/modes/treemode/contextmenu/createTreeContextMenuItems.ts
+++ b/src/lib/components/modes/treemode/contextmenu/createTreeContextMenuItems.ts
@@ -62,7 +62,7 @@ export default function ({
 }: {
   json: unknown
   documentState: DocumentState | undefined
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   readOnly: boolean
   parser: JSONParser
   onEditKey: () => void

--- a/src/lib/components/modes/treemode/menu/TreeMenu.svelte
+++ b/src/lib/components/modes/treemode/menu/TreeMenu.svelte
@@ -19,7 +19,7 @@
   import type { HistoryState } from '$lib/logic/history.js'
 
   export let json: unknown
-  export let selection: JSONSelection | null
+  export let selection: JSONSelection | undefined
 
   export let readOnly: boolean
   export let showSearch = false

--- a/src/lib/components/modes/treemode/singleton.ts
+++ b/src/lib/components/modes/treemode/singleton.ts
@@ -3,18 +3,18 @@ import type { JSONPath } from 'immutable-json-patch'
 
 export const singleton: Singleton = {
   selecting: false,
-  selectionAnchor: null, // Path
-  selectionAnchorType: null, // Selection type
-  selectionFocus: null, // Path
+  selectionAnchor: undefined, // Path
+  selectionAnchorType: undefined, // Selection type
+  selectionFocus: undefined, // Path
 
   dragging: false
 }
 
 interface Singleton {
   selecting: boolean
-  selectionAnchor: JSONPath | null
-  selectionAnchorType: string | null
-  selectionFocus: JSONPath | null
+  selectionAnchor: JSONPath | undefined
+  selectionAnchorType: string | undefined
+  selectionFocus: JSONPath | undefined
 
   dragging: boolean
 }

--- a/src/lib/logic/actions.ts
+++ b/src/lib/logic/actions.ts
@@ -75,7 +75,7 @@ export async function onCut({
   }
 
   const clipboard = selectionToPartialJson(json, selection, indentation, parser)
-  if (clipboard == null) {
+  if (clipboard === undefined) {
     return
   }
 
@@ -101,7 +101,7 @@ export interface OnCopyAction {
 // TODO: write unit tests
 export async function onCopy({ json, selection, indentation, parser }: OnCopyAction) {
   const clipboard = selectionToPartialJson(json, selection, indentation, parser)
-  if (clipboard == null) {
+  if (clipboard === undefined) {
     return
   }
 
@@ -140,11 +140,11 @@ export function onPaste({
 
   function doPaste(pastedText: string) {
     if (json !== undefined) {
-      const selectionNonNull = selection || createValueSelection([], false)
+      const ensureSelection = selection || createValueSelection([], false)
 
-      const operations = insert(json, selectionNonNull, pastedText, parser)
+      const operations = insert(json, ensureSelection, pastedText, parser)
 
-      debug('paste', { pastedText, operations, selectionNonNull })
+      debug('paste', { pastedText, operations, ensureSelection })
 
       onPatch(operations, (patchedJson, patchedState) => {
         let updatedState = patchedState
@@ -483,7 +483,7 @@ export function onInsert({
 
         if (newValue === '') {
           // open the newly inserted value in edit mode
-          const parent = !isEmpty(path) ? getIn(patchedJson, initial(path)) : null
+          const parent = !isEmpty(path) ? getIn(patchedJson, initial(path)) : undefined
 
           return {
             // expandPath is invoked to make sure that visibleSections is extended when needed

--- a/src/lib/logic/actions.ts
+++ b/src/lib/logic/actions.ts
@@ -176,6 +176,8 @@ export function onPaste({
             state: expandRecursive(patchedJson, patchedState, path)
           }
         }
+
+        return undefined
       })
     }
   }
@@ -491,9 +493,9 @@ export function onInsert({
               : createValueSelection(path, true)
           }
         }
-
-        return undefined
       }
+
+      return undefined
     })
 
     debug('after patch')

--- a/src/lib/logic/actions.ts
+++ b/src/lib/logic/actions.ts
@@ -54,7 +54,7 @@ const debug = createDebug('jsoneditor:actions')
 
 export interface OnCutAction {
   json: unknown | undefined
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   indentation: string | number | undefined
   readOnly: boolean
   parser: JSONParser
@@ -93,7 +93,7 @@ export async function onCut({
 
 export interface OnCopyAction {
   json: unknown
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   indentation: string | number | undefined
   parser: JSONParser
 }
@@ -115,7 +115,7 @@ type RepairModalCallback = (text: string, onApply: (repairedText: string) => voi
 interface OnPasteAction {
   clipboardText: string
   json: unknown | undefined
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   readOnly: boolean
   parser: JSONParser
   onPatch: OnPatch
@@ -193,7 +193,7 @@ export function onPaste({
 export interface OnRemoveAction {
   json: unknown | undefined
   text: string | undefined
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   keepSelection: boolean
   readOnly: boolean
   onChange: OnChange
@@ -230,8 +230,8 @@ export function onRemove({
         { text: '', json: undefined },
         json !== undefined ? { text: undefined, json } : { text: text || '', json },
         {
-          contentErrors: null,
-          patchResult: null
+          contentErrors: undefined,
+          patchResult: undefined
         }
       )
     }
@@ -252,7 +252,7 @@ export function onRemove({
 
 export interface OnDuplicateRowAction {
   json: unknown | undefined
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   columns: JSONPath[]
   readOnly: boolean
   onPatch: OnPatch
@@ -295,7 +295,7 @@ export function onDuplicateRow({
 
 export interface OnInsertBeforeRowAction {
   json: unknown | undefined
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   columns: JSONPath[]
   readOnly: boolean
   onPatch: OnPatch
@@ -331,7 +331,7 @@ export function onInsertBeforeRow({
 
 export interface OnInsertAfterRowAction {
   json: unknown | undefined
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   columns: JSONPath[]
   readOnly: boolean
   onPatch: OnPatch
@@ -380,7 +380,7 @@ export function onInsertAfterRow({
 
 export interface OnRemoveRowAction {
   json: unknown | undefined
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   columns: JSONPath[]
   readOnly: boolean
   onPatch: OnPatch
@@ -417,7 +417,7 @@ export function onRemoveRow({ json, selection, columns, readOnly, onPatch }: OnR
             fromTableCellPosition({ rowIndex: newRowIndex, columnIndex }, columns),
             false
           )
-        : null
+        : undefined
 
     debug('remove row new selection', { rowIndex, newRowIndex, newSelection })
 
@@ -433,7 +433,7 @@ export interface OnInsert {
   selectInside: boolean
   refJsonEditor: HTMLElement
   json: unknown | undefined
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   readOnly: boolean
   parser: JSONParser
   onPatch: OnPatch
@@ -523,7 +523,7 @@ export interface OnInsertCharacter {
   selectInside: boolean
   refJsonEditor: HTMLElement
   json: unknown | undefined
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   readOnly: boolean
   parser: JSONParser
   onPatch: OnPatch
@@ -625,7 +625,7 @@ interface OnInsertValueWithCharacter {
   char: string
   refJsonEditor: HTMLElement
   json: unknown | undefined
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   readOnly: boolean
   parser: JSONParser
   onPatch: OnPatch

--- a/src/lib/logic/documentState.test.ts
+++ b/src/lib/logic/documentState.test.ts
@@ -957,7 +957,7 @@ describe('documentState', () => {
         res.state,
         updateIn(documentState, ['properties', 'members'], (state: DocumentState) => ({
           ...state,
-          items: state.type === 'array' ? state.items.slice(0, 2) : null,
+          items: state.type === 'array' ? state.items.slice(0, 2) : undefined,
           visibleSections: [{ start: 0, end: 2 }]
         }))
       )
@@ -979,7 +979,7 @@ describe('documentState', () => {
         res.state,
         updateIn(documentState, ['properties', 'members'], (state: DocumentState) => ({
           ...state,
-          items: state.type === 'array' ? [state.items[0], state.items[2]] : null,
+          items: state.type === 'array' ? [state.items[0], state.items[2]] : undefined,
           visibleSections: [{ start: 0, end: 2 }]
         }))
       )
@@ -1135,7 +1135,7 @@ describe('documentState', () => {
                   state.items[1],
                   state.items[2]
                 ]
-              : null,
+              : undefined,
           visibleSections: [{ start: 0, end: 4 }]
         }))
       )
@@ -1208,7 +1208,8 @@ describe('documentState', () => {
         updateIn(documentState, ['properties', 'members'], (state: DocumentState | undefined) => {
           return {
             ...state,
-            items: state?.type === 'array' ? [state.items[1], state.items[0], state.items[2]] : null
+            items:
+              state?.type === 'array' ? [state.items[1], state.items[0], state.items[2]] : undefined
           }
         })
       )
@@ -1243,7 +1244,8 @@ describe('documentState', () => {
         updateIn(documentState, ['properties', 'members'], (state: DocumentState | undefined) => {
           return {
             ...state,
-            items: state?.type === 'array' ? [state.items[1], state.items[0], state.items[2]] : null
+            items:
+              state?.type === 'array' ? [state.items[1], state.items[0], state.items[2]] : undefined
           }
         })
       )
@@ -1290,7 +1292,7 @@ describe('documentState', () => {
                   state.items[1],
                   state.items[2]
                 ]
-              : null,
+              : undefined,
           visibleSections: [{ start: 0, end: 4 }]
         })
       )
@@ -1323,7 +1325,7 @@ describe('documentState', () => {
         ['properties', 'members'],
         (state: DocumentState) => ({
           ...state,
-          items: state.type === 'array' ? [state.items[0], state.items[2]] : null,
+          items: state.type === 'array' ? [state.items[0], state.items[2]] : undefined,
           visibleSections: [{ start: 0, end: 2 }]
         })
       )

--- a/src/lib/logic/documentState.ts
+++ b/src/lib/logic/documentState.ts
@@ -828,6 +828,8 @@ export function getPreviousVisiblePath(
   if (index !== -1 && index > 0) {
     return visiblePaths[index - 1]
   }
+
+  return undefined
 }
 
 /**
@@ -847,6 +849,8 @@ export function getNextVisiblePath(
   if (index !== -1 && index < visiblePaths.length - 1) {
     return visiblePaths[index + 1]
   }
+
+  return undefined
 }
 
 /**

--- a/src/lib/logic/documentState.ts
+++ b/src/lib/logic/documentState.ts
@@ -819,7 +819,7 @@ export function getPreviousVisiblePath(
   json: unknown,
   documentState: DocumentState | undefined,
   path: JSONPath
-): JSONPath | null {
+): JSONPath | undefined {
   const visiblePaths = getVisiblePaths(json, documentState)
   const visiblePathPointers = visiblePaths.map(compileJSONPointer)
   const pathPointer = compileJSONPointer(path)
@@ -828,8 +828,6 @@ export function getPreviousVisiblePath(
   if (index !== -1 && index > 0) {
     return visiblePaths[index - 1]
   }
-
-  return null
 }
 
 /**
@@ -841,7 +839,7 @@ export function getNextVisiblePath(
   json: unknown,
   documentState: DocumentState | undefined,
   path: JSONPath
-): JSONPath | null {
+): JSONPath | undefined {
   const visiblePaths = getVisiblePaths(json, documentState)
   const visiblePathPointers = visiblePaths.map(compileJSONPointer)
   const index = visiblePathPointers.indexOf(compileJSONPointer(path))
@@ -849,8 +847,6 @@ export function getNextVisiblePath(
   if (index !== -1 && index < visiblePaths.length - 1) {
     return visiblePaths[index + 1]
   }
-
-  return null
 }
 
 /**

--- a/src/lib/logic/dragging.ts
+++ b/src/lib/logic/dragging.ts
@@ -13,14 +13,14 @@ import type {
 
 export interface MoveSelectionProps {
   json: unknown
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   deltaY: number
   items: RenderedItem[]
 }
 
 export interface MoveSelectionResult {
   operations: JSONPatchDocument | undefined
-  updatedSelection: JSONSelection | null
+  updatedSelection: JSONSelection | undefined
   offset: number
 }
 
@@ -33,7 +33,7 @@ export function onMoveSelection({
   if (!selection) {
     return {
       operations: undefined,
-      updatedSelection: null,
+      updatedSelection: undefined,
       offset: 0
     }
   }
@@ -46,7 +46,7 @@ export function onMoveSelection({
   if (!dragInsideAction || dragInsideAction.offset === 0) {
     return {
       operations: undefined,
-      updatedSelection: null,
+      updatedSelection: undefined,
       offset: 0
     }
   }
@@ -72,7 +72,7 @@ export function onMoveSelection({
     // object
     return {
       operations,
-      updatedSelection: null,
+      updatedSelection: undefined,
       offset: dragInsideAction.offset
     }
   }

--- a/src/lib/logic/operations.test.ts
+++ b/src/lib/logic/operations.test.ts
@@ -15,15 +15,15 @@ import { immutableJSONPatch } from 'immutable-json-patch'
 describe('operations', () => {
   describe('createNewValue', () => {
     test('should create a value of type "value"', () => {
-      assert.strictEqual(createNewValue({}, null, 'value'), '')
+      assert.strictEqual(createNewValue({}, undefined, 'value'), '')
     })
 
     test('should create a value of type "object"', () => {
-      assert.deepStrictEqual(createNewValue({}, null, 'object'), {})
+      assert.deepStrictEqual(createNewValue({}, undefined, 'object'), {})
     })
 
     test('should create a value of type "array"', () => {
-      assert.deepStrictEqual(createNewValue({}, null, 'array'), [])
+      assert.deepStrictEqual(createNewValue({}, undefined, 'array'), [])
     })
 
     test('should create a simple value via type "structure"', () => {

--- a/src/lib/logic/operations.ts
+++ b/src/lib/logic/operations.ts
@@ -339,7 +339,7 @@ export function extract(json: unknown, selection: JSONSelection): JSONPatchDocum
 // TODO: write unit tests
 export function insert(
   json: unknown,
-  selection: JSONSelection | null,
+  selection: JSONSelection | undefined,
   clipboardText: string,
   parser: JSONParser
 ): JSONPatchDocument {
@@ -445,7 +445,7 @@ export function insert(
 
 export function moveInsideParent(
   json: unknown,
-  selection: JSONSelection | null,
+  selection: JSONSelection | undefined,
   dragInsideAction: DragInsideAction
 ): JSONPatchDocument {
   if (!selection) {
@@ -529,7 +529,7 @@ export function moveInsideParent(
 
 export function createNewValue(
   json: unknown | undefined,
-  selection: JSONSelection | null,
+  selection: JSONSelection | undefined,
   valueType: 'object' | 'array' | 'structure' | 'value'
 ): unknown {
   if (valueType === 'object') {
@@ -642,7 +642,7 @@ export function clipboardToValues(clipboardText: string, parser: JSONParser): Cl
 export function createRemoveOperations(
   json: unknown,
   selection: JSONSelection
-): { newSelection: JSONSelection | null; operations: JSONPatchDocument } {
+): { newSelection: JSONSelection | undefined; operations: JSONPatchDocument } {
   if (isKeySelection(selection)) {
     // FIXME: DOESN'T work yet
     const parentPath = initial(selection.path)

--- a/src/lib/logic/search.ts
+++ b/src/lib/logic/search.ts
@@ -277,7 +277,7 @@ export function createSearchAndReplaceOperations(
   replacementText: string,
   searchResultItem: SearchResultItem,
   parser: JSONParser
-): { newSelection: JSONSelection | null; operations: JSONPatchDocument } {
+): { newSelection: JSONSelection | undefined; operations: JSONPatchDocument } {
   const { field, path, start, end } = searchResultItem
 
   if (field === SearchField.key) {
@@ -331,7 +331,7 @@ export function createSearchAndReplaceAllOperations(
   searchText: string,
   replacementText: string,
   parser: JSONParser
-): { newSelection: JSONSelection | null; operations: JSONPatchDocument } {
+): { newSelection: JSONSelection | undefined; operations: JSONPatchDocument } {
   // TODO: to improve performance, we could reuse existing search results (except when hitting a maxResult limit)
   const searchResultItems = search(searchText, json, { maxResults: Infinity })
 
@@ -377,7 +377,7 @@ export function createSearchAndReplaceAllOperations(
 
   // step 3: call createSearchAndReplaceOperations for each of the matches
   let allOperations: JSONPatchDocument = []
-  let lastNewSelection: JSONSelection | null = null
+  let lastNewSelection: JSONSelection | undefined
   deduplicatedMatches.forEach((match) => {
     // TODO: there is overlap with the logic of createSearchAndReplaceOperations. Can we extract and reuse this logic?
     const { field, path, items } = match

--- a/src/lib/logic/selection.test.ts
+++ b/src/lib/logic/selection.test.ts
@@ -240,7 +240,7 @@ describe('selection', () => {
 
       assert.deepStrictEqual(
         getSelectionRight(json2, documentState2, createInsideSelection(['path'])),
-        null
+        undefined
       )
 
       assert.deepStrictEqual(
@@ -509,7 +509,7 @@ describe('selection', () => {
 
         assert.deepStrictEqual(
           getSelectionDown(json3, documentState3, createAfterSelection(['arr']), false),
-          null
+          undefined
         )
       })
     })
@@ -569,11 +569,11 @@ describe('selection', () => {
     )
     assert.deepStrictEqual(
       selectionToPartialJson(json, createAfterSelection(['str']), 2, JSON),
-      null
+      undefined
     )
     assert.deepStrictEqual(
       selectionToPartialJson(json, createInsideSelection(['str']), 2, JSON),
-      null
+      undefined
     )
 
     assert.deepStrictEqual(
@@ -722,7 +722,7 @@ describe('selection', () => {
     test('should get selection from removing a key', () => {
       assert.deepStrictEqual(
         createSelectionFromOperations(json, [{ op: 'remove', path: '/str' }]),
-        null
+        undefined
       )
     })
 
@@ -767,7 +767,10 @@ describe('selection', () => {
       assert.deepStrictEqual(selectionIfOverlapping(json, selection, []), selection)
       assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['obj']), selection)
       assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['obj', 'arr']), selection)
-      assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['obj', 'arr', '0']), null)
+      assert.deepStrictEqual(
+        selectionIfOverlapping(json, selection, ['obj', 'arr', '0']),
+        undefined
+      )
     })
 
     test('should determine whether a ValueSelection is relevant for given pointer', () => {
@@ -788,7 +791,10 @@ describe('selection', () => {
       assert.deepStrictEqual(selectionIfOverlapping(json, selection, []), selection)
       assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['obj']), selection)
       assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['obj', 'arr']), selection)
-      assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['obj', 'arr', '0']), null)
+      assert.deepStrictEqual(
+        selectionIfOverlapping(json, selection, ['obj', 'arr', '0']),
+        undefined
+      )
     })
 
     test('should determine whether an InsideSelection is relevant for given pointer', () => {
@@ -797,7 +803,10 @@ describe('selection', () => {
       assert.deepStrictEqual(selectionIfOverlapping(json, selection, []), selection)
       assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['obj']), selection)
       assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['obj', 'arr']), selection)
-      assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['obj', 'arr', '0']), null)
+      assert.deepStrictEqual(
+        selectionIfOverlapping(json, selection, ['obj', 'arr', '0']),
+        undefined
+      )
     })
 
     test('should determine whether a MultiSelection is relevant for given pointer', () => {
@@ -826,9 +835,9 @@ describe('selection', () => {
         selectionIfOverlapping(json, selection, ['obj', 'arr', '2', 'last']),
         selection
       )
-      assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['str']), null)
-      assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['nill']), null)
-      assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['bool']), null)
+      assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['str']), undefined)
+      assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['nill']), undefined)
+      assert.deepStrictEqual(selectionIfOverlapping(json, selection, ['bool']), undefined)
     })
   })
 

--- a/src/lib/logic/selection.ts
+++ b/src/lib/logic/selection.ts
@@ -746,6 +746,7 @@ export function canConvert(selection: JSONSelection | undefined): boolean {
 }
 
 // TODO: unit test
+// eslint-disable-next-line consistent-return
 export function fromCaretPosition(caretPosition: CaretPosition): JSONSelection {
   switch (caretPosition.type) {
     case CaretType.key:
@@ -760,11 +761,8 @@ export function fromCaretPosition(caretPosition: CaretPosition): JSONSelection {
 }
 
 // TODO: unit test
-export function fromSelectionType(
-  json: unknown,
-  selectionType: SelectionType,
-  path: JSONPath
-): JSONSelection {
+// eslint-disable-next-line consistent-return
+export function fromSelectionType(selectionType: SelectionType, path: JSONPath): JSONSelection {
   switch (selectionType) {
     case SelectionType.key:
       return createKeySelection(path, false)

--- a/src/lib/logic/selection.ts
+++ b/src/lib/logic/selection.ts
@@ -255,7 +255,7 @@ export function getSelectionUp(
   }
 
   if (isKeySelection(selection)) {
-    if (previousPath == null || previousPath.length === 0) {
+    if (previousPath === undefined || previousPath.length === 0) {
       return undefined
     }
 

--- a/src/lib/logic/selection.ts
+++ b/src/lib/logic/selection.ts
@@ -35,40 +35,44 @@ import { CaretType, SelectionType } from '$lib/types.js'
 import { int } from '$lib/utils/numberUtils.js'
 
 export function isAfterSelection(
-  selection: JSONEditorSelection | null
+  selection: JSONEditorSelection | undefined
 ): selection is AfterSelection {
   return (selection && selection.type === SelectionType.after) || false
 }
 
 export function isInsideSelection(
-  selection: JSONEditorSelection | null
+  selection: JSONEditorSelection | undefined
 ): selection is InsideSelection {
   return (selection && selection.type === SelectionType.inside) || false
 }
 
-export function isKeySelection(selection: JSONEditorSelection | null): selection is KeySelection {
+export function isKeySelection(
+  selection: JSONEditorSelection | undefined
+): selection is KeySelection {
   return (selection && selection.type === SelectionType.key) || false
 }
 
 export function isValueSelection(
-  selection: JSONEditorSelection | null
+  selection: JSONEditorSelection | undefined
 ): selection is ValueSelection {
   return (selection && selection.type === SelectionType.value) || false
 }
 
 export function isMultiSelection(
-  selection: JSONEditorSelection | null
+  selection: JSONEditorSelection | undefined
 ): selection is MultiSelection {
   return (selection && selection.type === SelectionType.multi) || false
 }
 
 export function isMultiSelectionWithOneItem(
-  selection: JSONEditorSelection | null
+  selection: JSONEditorSelection | undefined
 ): selection is MultiSelection {
   return isMultiSelection(selection) && isEqual(selection.focusPath, selection.anchorPath)
 }
 
-export function isJSONSelection(selection: JSONEditorSelection | null): selection is JSONSelection {
+export function isJSONSelection(
+  selection: JSONEditorSelection | undefined
+): selection is JSONSelection {
   return (
     isMultiSelection(selection) ||
     isAfterSelection(selection) ||
@@ -78,7 +82,9 @@ export function isJSONSelection(selection: JSONEditorSelection | null): selectio
   )
 }
 
-export function isTextSelection(selection: JSONEditorSelection | null): selection is TextSelection {
+export function isTextSelection(
+  selection: JSONEditorSelection | undefined
+): selection is TextSelection {
   return (selection && selection.type === SelectionType.text) || false
 }
 
@@ -108,7 +114,7 @@ export function getSelectionPaths(json: unknown, selection: JSONSelection): JSON
  */
 export function iterateOverSelection<T>(
   json: unknown | undefined,
-  selection: JSONSelection | null,
+  selection: JSONSelection | undefined,
   callback: (path: JSONPath) => void | undefined | T
 ): void | undefined | T {
   if (!selection) {
@@ -216,11 +222,11 @@ export function isSelectionInsidePath(selection: JSONSelection, path: JSONPath):
 export function getSelectionUp(
   json: unknown,
   documentState: DocumentState | undefined,
-  selection: JSONSelection | null,
+  selection: JSONSelection | undefined,
   keepAnchorPath = false
-): JSONSelection | null {
+): JSONSelection | undefined {
   if (!selection) {
-    return null
+    return undefined
   }
 
   const focusPath = keepAnchorPath ? getFocusPath(selection) : getStartPath(json, selection)
@@ -229,12 +235,12 @@ export function getSelectionUp(
   if (keepAnchorPath) {
     // create a multi-selection with multiple nodes
     if (isInsideSelection(selection) || isAfterSelection(selection)) {
-      return previousPath !== null ? createMultiSelection(focusPath, focusPath) : null
+      return previousPath !== undefined ? createMultiSelection(focusPath, focusPath) : undefined
     }
 
-    return previousPath !== null
+    return previousPath !== undefined
       ? createMultiSelection(getAnchorPath(selection), previousPath)
-      : null
+      : undefined
   }
 
   if (isAfterSelection(selection)) {
@@ -250,7 +256,7 @@ export function getSelectionUp(
 
   if (isKeySelection(selection)) {
     if (previousPath == null || previousPath.length === 0) {
-      return null
+      return undefined
     }
 
     const parentPath = initial(previousPath)
@@ -264,24 +270,24 @@ export function getSelectionUp(
   }
 
   if (isValueSelection(selection)) {
-    return previousPath !== null ? createValueSelection(previousPath, false) : null
+    return previousPath !== undefined ? createValueSelection(previousPath, false) : undefined
   }
 
-  if (previousPath !== null) {
+  if (previousPath !== undefined) {
     return createValueSelection(previousPath, false)
   }
 
-  return null
+  return undefined
 }
 
 export function getSelectionDown(
   json: unknown,
   documentState: DocumentState | undefined,
-  selection: JSONSelection | null,
+  selection: JSONSelection | undefined,
   keepAnchorPath = false
-): JSONSelection | null {
+): JSONSelection | undefined {
   if (!selection) {
-    return null
+    return undefined
   }
   const focusPath = keepAnchorPath ? getFocusPath(selection) : getEndPath(json, selection)
 
@@ -297,33 +303,35 @@ export function getSelectionDown(
   if (keepAnchorPath) {
     // create a multi-selection with multiple nodes
     if (isInsideSelection(selection)) {
-      return nextPath !== null ? createMultiSelection(nextPath, nextPath) : null
+      return nextPath !== undefined ? createMultiSelection(nextPath, nextPath) : undefined
     }
 
     if (isAfterSelection(selection)) {
-      return nextPathAfter !== null ? createMultiSelection(nextPathAfter, nextPathAfter) : null
+      return nextPathAfter !== undefined
+        ? createMultiSelection(nextPathAfter, nextPathAfter)
+        : undefined
     }
 
-    return nextPathAfter !== null
+    return nextPathAfter !== undefined
       ? createMultiSelection(getAnchorPath(selection), nextPathAfter)
-      : null
+      : undefined
   }
 
   if (isAfterSelection(selection)) {
-    return nextPathAfter !== null ? createValueSelection(nextPathAfter, false) : null
+    return nextPathAfter !== undefined ? createValueSelection(nextPathAfter, false) : undefined
   }
 
   if (isInsideSelection(selection)) {
-    return nextPath !== null ? createValueSelection(nextPath, false) : null
+    return nextPath !== undefined ? createValueSelection(nextPath, false) : undefined
   }
 
   if (isValueSelection(selection)) {
-    return nextPath !== null ? createValueSelection(nextPath, false) : null
+    return nextPath !== undefined ? createValueSelection(nextPath, false) : undefined
   }
 
   if (isKeySelection(selection)) {
-    if (nextPath === null || nextPath.length === 0) {
-      return null
+    if (nextPath === undefined || nextPath.length === 0) {
+      return undefined
     }
 
     const parentPath = initial(nextPath) // not nextPathAfter!
@@ -337,14 +345,14 @@ export function getSelectionDown(
   }
 
   if (isMultiSelection(selection)) {
-    return nextPathAfter !== null
+    return nextPathAfter !== undefined
       ? createValueSelection(nextPathAfter, false)
-      : nextPath !== null
+      : nextPath !== undefined
         ? createValueSelection(nextPath, false)
-        : null
+        : undefined
   }
 
-  return null
+  return undefined
 }
 
 /**
@@ -355,9 +363,8 @@ export function getSelectionDown(
 export function getSelectionNextInside(
   json: unknown,
   documentState: DocumentState | undefined,
-  selection: JSONSelection | null,
   path: JSONPath
-): JSONSelection | null {
+): JSONSelection | undefined {
   // TODO: write unit tests for getSelectionNextInside
   const parentPath = initial(path)
   const childPath = [last(path) as string]
@@ -379,11 +386,15 @@ export function getSelectionNextInside(
 export function findCaretAndSiblings(
   json: unknown,
   documentState: DocumentState | undefined,
-  selection: JSONSelection | null,
+  selection: JSONSelection | undefined,
   includeInside: boolean
-): { next: CaretPosition | null; caret: CaretPosition | null; previous: CaretPosition | null } {
+): {
+  next: CaretPosition | undefined
+  caret: CaretPosition | undefined
+  previous: CaretPosition | undefined
+} {
   if (!selection) {
-    return { caret: null, previous: null, next: null }
+    return { caret: undefined, previous: undefined, next: undefined }
   }
   const visibleCaretPositions = getVisibleCaretPositions(json, documentState, includeInside)
 
@@ -394,26 +405,26 @@ export function findCaretAndSiblings(
   })
 
   return {
-    caret: index !== -1 ? visibleCaretPositions[index] : null,
+    caret: index !== -1 ? visibleCaretPositions[index] : undefined,
 
-    previous: index !== -1 && index > 0 ? visibleCaretPositions[index - 1] : null,
+    previous: index !== -1 && index > 0 ? visibleCaretPositions[index - 1] : undefined,
 
     next:
       index !== -1 && index < visibleCaretPositions.length - 1
         ? visibleCaretPositions[index + 1]
-        : null
+        : undefined
   }
 }
 
 export function getSelectionLeft(
   json: unknown,
   documentState: DocumentState | undefined,
-  selection: JSONSelection | null,
+  selection: JSONSelection | undefined,
   keepAnchorPath = false,
   includeInside = true
-): JSONSelection | null {
+): JSONSelection | undefined {
   if (!selection) {
-    return null
+    return undefined
   }
 
   const { caret, previous } = findCaretAndSiblings(json, documentState, selection, includeInside)
@@ -423,7 +434,7 @@ export function getSelectionLeft(
       return createMultiSelection(selection.path, selection.path)
     }
 
-    return null
+    return undefined
   }
 
   if (caret && previous) {
@@ -441,18 +452,18 @@ export function getSelectionLeft(
     return createKeySelection(selection.focusPath, false)
   }
 
-  return null
+  return undefined
 }
 
 export function getSelectionRight(
   json: unknown,
   documentState: DocumentState | undefined,
-  selection: JSONSelection | null,
+  selection: JSONSelection | undefined,
   keepAnchorPath = false,
   includeInside = true
-): JSONSelection | null {
+): JSONSelection | undefined {
   if (!selection) {
-    return null
+    return undefined
   }
 
   const { caret, next } = findCaretAndSiblings(json, documentState, selection, includeInside)
@@ -462,7 +473,7 @@ export function getSelectionRight(
       return createMultiSelection(selection.path, selection.path)
     }
 
-    return null
+    return undefined
   }
 
   if (caret && next) {
@@ -473,7 +484,7 @@ export function getSelectionRight(
     return createValueSelection(selection.focusPath, false)
   }
 
-  return null
+  return undefined
 }
 
 /**
@@ -503,7 +514,7 @@ export function getInitialSelection(
 export function createSelectionFromOperations(
   json: unknown,
   operations: JSONPatchDocument
-): JSONSelection | null {
+): JSONSelection | undefined {
   if (operations.length === 1) {
     const operation = first(operations) as JSONPatchOperation
     if (operation.op === 'replace') {
@@ -542,7 +553,7 @@ export function createSelectionFromOperations(
     .map((operation) => parsePath(json, operation.path))
 
   if (isEmpty(paths)) {
-    return null
+    return undefined
   }
 
   // TODO: make this function robust against operations which do not have consecutive paths or have wrongly ordered paths
@@ -568,7 +579,7 @@ export function findSharedPath(path1: JSONPath, path2: JSONPath): JSONPath {
   return path1.slice(0, i)
 }
 
-export function singleItemSelected(selection: JSONSelection | null): boolean {
+export function singleItemSelected(selection: JSONSelection | undefined): boolean {
   return (
     isKeySelection(selection) ||
     isValueSelection(selection) ||
@@ -598,7 +609,9 @@ export function pathStartsWith(path: JSONPath, parentPath: JSONPath): boolean {
 }
 
 // TODO: write unit tests
-export function removeEditModeFromSelection(selection: JSONSelection | null): JSONSelection | null {
+export function removeEditModeFromSelection(
+  selection: JSONSelection | undefined
+): JSONSelection | undefined {
   if ((isKeySelection(selection) || isValueSelection(selection)) && selection.edit) {
     return { ...selection, edit: false }
   }
@@ -654,23 +667,23 @@ export function createMultiSelection(anchorPath: JSONPath, focusPath: JSONPath):
  */
 export function selectionToPartialJson(
   json: unknown,
-  selection: JSONSelection | null,
+  selection: JSONSelection | undefined,
   indentation: number | string | undefined,
   parser: JSONParser
-): string | null {
+): string | undefined {
   if (isKeySelection(selection)) {
     return String(last(selection.path))
   }
 
   if (isValueSelection(selection)) {
     const value = getIn(json, selection.path)
-    return typeof value === 'string' ? value : parser.stringify(value, null, indentation) ?? null // TODO: customizable indentation?
+    return typeof value === 'string' ? value : parser.stringify(value, null, indentation) // TODO: customizable indentation?
   }
 
   if (isMultiSelection(selection)) {
     if (isEmpty(selection.focusPath)) {
       // root object -> does not have a parent key/index
-      return parser.stringify(json, null, indentation) ?? null
+      return parser.stringify(json, null, indentation)
     }
 
     const parentPath = getParentPath(selection)
@@ -679,7 +692,7 @@ export function selectionToPartialJson(
       if (isMultiSelectionWithOneItem(selection)) {
         // do not suffix a single selected array item with a comma
         const item = getIn(json, selection.focusPath)
-        return parser.stringify(item, null, indentation) ?? null
+        return parser.stringify(item, null, indentation)
       } else {
         return getSelectionPaths(json, selection)
           .map((path) => {
@@ -700,10 +713,10 @@ export function selectionToPartialJson(
     }
   }
 
-  return null
+  return undefined
 }
 
-export function isEditingSelection(selection: JSONSelection | null): boolean {
+export function isEditingSelection(selection: JSONSelection | undefined): boolean {
   return (isKeySelection(selection) || isValueSelection(selection)) && selection.edit === true
 }
 
@@ -716,7 +729,7 @@ export function selectAll(): JSONSelection {
 }
 
 // TODO: write unit tests
-export function hasSelectionContents(selection: JSONSelection | null): boolean {
+export function hasSelectionContents(selection: JSONSelection | undefined): boolean {
   return isKeySelection(selection) || isValueSelection(selection) || isMultiSelection(selection)
 }
 
@@ -724,7 +737,7 @@ export function hasSelectionContents(selection: JSONSelection | null): boolean {
  * Test whether the current selection can be converted.
  * That is the case when the selection is a key/value, or a multi selection with only one path
  */
-export function canConvert(selection: JSONSelection | null): boolean {
+export function canConvert(selection: JSONSelection | undefined): boolean {
   return (
     isKeySelection(selection) ||
     isValueSelection(selection) ||
@@ -769,11 +782,11 @@ export function fromSelectionType(
 
 export function selectionIfOverlapping(
   json: unknown | undefined,
-  selection: JSONSelection | null,
+  selection: JSONSelection | undefined,
   path: JSONPath
-): JSONSelection | null {
+): JSONSelection | undefined {
   if (!selection) {
-    return null
+    return undefined
   }
 
   if (pathInSelection(json, selection, path)) {
@@ -785,12 +798,12 @@ export function selectionIfOverlapping(
     return selection
   }
 
-  return null
+  return undefined
 }
 
 export function pathInSelection(
   json: unknown | undefined,
-  selection: JSONSelection | null,
+  selection: JSONSelection | undefined,
   path: JSONPath
 ): boolean {
   if (json === undefined || !selection) {

--- a/src/lib/logic/table.test.ts
+++ b/src/lib/logic/table.test.ts
@@ -90,6 +90,10 @@ describe('table', () => {
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
+    deepStrictEqual(getColumns(undefined, false), [])
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     deepStrictEqual(getColumns('foo', false), [])
   })
 

--- a/src/lib/logic/table.ts
+++ b/src/lib/logic/table.ts
@@ -432,19 +432,19 @@ function findColumnIndex(error: ValidationError, columns: JSONPath[]): number {
  * Clear the sorted column from the documentState when it is affected by the operations
  */
 export function clearSortedColumnWhenAffectedByOperations(
-  sortedColumn: SortedColumn | null,
+  sortedColumn: SortedColumn | undefined,
   operations: JSONPatchOperation[],
   columms: JSONPath[]
-): SortedColumn | null {
+): SortedColumn | undefined {
   const mustBeCleared = operations.some((operation) =>
     operationAffectsSortedColumn(sortedColumn, operation, columms)
   )
 
-  return mustBeCleared ? null : sortedColumn
+  return mustBeCleared ? undefined : sortedColumn
 }
 
 export function operationAffectsSortedColumn(
-  sortedColumn: SortedColumn | null,
+  sortedColumn: SortedColumn | undefined,
   operation: JSONPatchOperation,
   columns: JSONPath[]
 ): boolean {

--- a/src/lib/logic/validation.test.ts
+++ b/src/lib/logic/validation.test.ts
@@ -173,7 +173,7 @@ describe('validation', () => {
     const invalidText = '{ "foo": 42 }'
 
     test('should validateText with native parser and valid JSON', () => {
-      deepStrictEqual(validateText(validText, myValidator, JSON, JSON), null)
+      deepStrictEqual(validateText(validText, myValidator, JSON, JSON), undefined)
     })
 
     test('should validateText with native parser and invalid JSON', () => {
@@ -183,7 +183,7 @@ describe('validation', () => {
     })
 
     test('should validateText with lossless parser and valid JSON', () => {
-      deepStrictEqual(validateText(validText, myValidator, LosslessJSONParser, JSON), null)
+      deepStrictEqual(validateText(validText, myValidator, LosslessJSONParser, JSON), undefined)
     })
 
     test('should validateText with lossless parser and invalid JSON', () => {
@@ -195,7 +195,7 @@ describe('validation', () => {
     test('should validateText with two lossless parsers and valid JSON', () => {
       deepStrictEqual(
         validateText(validText, myLosslessValidator, LosslessJSONParser, LosslessJSONParser),
-        null
+        undefined
       )
     })
 
@@ -211,7 +211,7 @@ describe('validation', () => {
     test('should validateText with a non-repairable parse error', () => {
       const invalidText = '{\n  "name": "Joe" }[]'
 
-      deepStrictEqual(validateText(invalidText, null, LosslessJSONParser, JSON), {
+      deepStrictEqual(validateText(invalidText, undefined, LosslessJSONParser, JSON), {
         isRepairable: false,
         parseError: {
           column: 17,
@@ -225,7 +225,7 @@ describe('validation', () => {
     test('should validateText with a repairable parse error', () => {
       const invalidText = '{\n  "name": "Joe"'
 
-      deepStrictEqual(validateText(invalidText, null, LosslessJSONParser, JSON), {
+      deepStrictEqual(validateText(invalidText, undefined, LosslessJSONParser, JSON), {
         isRepairable: true,
         parseError: {
           column: 15,
@@ -240,7 +240,7 @@ describe('validation', () => {
     test('should validateText with duplicate keys', () => {
       const duplicateKeysText = '{\n  "name": "Joe",\n  "age": 23,\n  "name": "Sarah"\n}'
 
-      deepStrictEqual(validateText(duplicateKeysText, null, LosslessJSONParser, JSON), {
+      deepStrictEqual(validateText(duplicateKeysText, undefined, LosslessJSONParser, JSON), {
         isRepairable: false,
         parseError: {
           column: 3,

--- a/src/lib/logic/validation.ts
+++ b/src/lib/logic/validation.ts
@@ -81,7 +81,7 @@ export function toRecursiveValidationErrors(
 
 export function validateJSON(
   json: unknown,
-  validator: Validator | null,
+  validator: Validator | undefined,
   parser: JSONParser,
   validationParser: JSONParser
 ): ValidationError[] {
@@ -104,10 +104,10 @@ export function validateJSON(
 
 export function validateText(
   text: string,
-  validator: Validator | null,
+  validator: Validator | undefined,
   parser: JSONParser,
   validationParser: JSONParser
-): ContentErrors | null {
+): ContentErrors | undefined {
   debug('validateText')
 
   if (text.length > MAX_VALIDATABLE_SIZE) {
@@ -124,7 +124,7 @@ export function validateText(
 
   if (text.length === 0) {
     // new, empty document, do not try to parse
-    return null
+    return undefined
   }
 
   try {
@@ -136,7 +136,7 @@ export function validateText(
     )
 
     if (!validator) {
-      return null
+      return undefined
     }
 
     // if needed, parse with the validationParser to be able to feed the json to the validator
@@ -154,7 +154,7 @@ export function validateText(
       (duration) => debug(`validate: validated json in ${duration} ms`)
     )
 
-    return !isEmpty(validationErrors) ? { validationErrors } : null
+    return !isEmpty(validationErrors) ? { validationErrors } : undefined
   } catch (err) {
     const isRepairable = measure(
       () => canAutoRepair(text, parser),

--- a/src/lib/plugins/value/components/EnumValue.svelte
+++ b/src/lib/plugins/value/components/EnumValue.svelte
@@ -11,7 +11,7 @@
   export let value: unknown
   export let parser: JSONParser
   export let readOnly: boolean
-  export let selection: JSONSelection | null
+  export let selection: JSONSelection | undefined
   export let onPatch: OnPatch
 
   export let options: Array<{ value: unknown; text: string }>
@@ -21,7 +21,7 @@
   let bindValue: unknown = value
   $: bindValue = value
 
-  function applyFocus(selection: JSONSelection | null) {
+  function applyFocus(selection: JSONSelection | undefined) {
     if (selection) {
       if (refSelect) {
         refSelect.focus()

--- a/src/lib/plugins/value/components/ReadonlyValue.svelte
+++ b/src/lib/plugins/value/components/ReadonlyValue.svelte
@@ -51,7 +51,7 @@
   class={getValueClass(value, parser)}
   on:click={handleValueClick}
   on:dblclick={handleValueDoubleClick}
-  title={valueIsUrl ? 'Ctrl+Click or Ctrl+Enter to open url in new window' : null}
+  title={valueIsUrl ? 'Ctrl+Click or Ctrl+Enter to open url in new window' : undefined}
 >
   {#if searchResultItems}
     <SearchResultHighlighter text={normalization.escapeValue(value)} {searchResultItems} />

--- a/src/lib/plugins/value/renderJSONSchemaEnum.ts
+++ b/src/lib/plugins/value/renderJSONSchemaEnum.ts
@@ -16,7 +16,7 @@ export function renderJSONSchemaEnum(
   props: RenderValueProps,
   schema: JSONSchema,
   schemaDefinitions?: JSONSchemaDefinitions
-): RenderValueComponentDescription[] | null {
+): RenderValueComponentDescription[] | undefined {
   const enumValues = getJSONSchemaOptions(schema, schemaDefinitions, props.path)
 
   if (enumValues) {
@@ -49,5 +49,5 @@ export function renderJSONSchemaEnum(
     ]
   }
 
-  return null
+  return undefined
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -172,13 +172,13 @@ export interface JSONPatchResult {
 export type AfterPatchCallback = (
   patchedJson: unknown,
   patchedState: DocumentState | undefined,
-  patchedSelection: JSONSelection | null
+  patchedSelection: JSONSelection | undefined
 ) =>
   | {
       json?: unknown
       state?: DocumentState | undefined
-      selection?: JSONSelection | null
-      sortedColumn?: SortedColumn | null
+      selection?: JSONSelection | undefined
+      sortedColumn?: SortedColumn | undefined
     }
   | undefined
 
@@ -299,9 +299,9 @@ export interface NestedValidationError extends ValidationError {
 export type Validator = (json: unknown) => ValidationError[]
 
 export interface ParseError {
-  position: number | null
-  line: number | null
-  column: number | null
+  position: number | undefined
+  line: number | undefined
+  column: number | undefined
   message: string
 }
 
@@ -317,11 +317,11 @@ export interface ContentValidationErrors {
 export type ContentErrors = ContentParseError | ContentValidationErrors
 
 export interface RichValidationError extends ValidationError {
-  line: number | null
-  column: number | null
-  from: number | null
-  to: number | null
-  actions: Array<{ name: string; apply: () => void }> | null
+  line: number | undefined
+  column: number | undefined
+  from: number | undefined
+  to: number | undefined
+  actions: Array<{ name: string; apply: () => void }> | undefined
 }
 
 export interface TextLocation {
@@ -362,14 +362,14 @@ export interface QueryLanguageOptions {
 
 export type OnChangeQueryLanguage = (queryLanguageId: string) => void
 export interface OnChangeStatus {
-  contentErrors: ContentErrors | null
-  patchResult: JSONPatchResult | null
+  contentErrors: ContentErrors | undefined
+  patchResult: JSONPatchResult | undefined
 }
 export type OnChange =
   | ((content: Content, previousContent: Content, status: OnChangeStatus) => void)
-  | null
+  | undefined
 export type OnJSONSelect = (selection: JSONSelection) => void
-export type OnSelect = (selection: JSONEditorSelection | null) => void
+export type OnSelect = (selection: JSONEditorSelection | undefined) => void
 export type OnPatch = (
   operations: JSONPatchDocument,
   afterPatch?: AfterPatchCallback
@@ -396,7 +396,9 @@ export type RenderMenuContext = {
 }
 export type OnRenderMenu = (items: MenuItem[], context: RenderMenuContext) => MenuItem[] | undefined
 export type OnRenderMenuInternal = (items: MenuItem[]) => MenuItem[]
-export type RenderContextMenuContext = RenderMenuContext & { selection: JSONEditorSelection | null }
+export type RenderContextMenuContext = RenderMenuContext & {
+  selection: JSONEditorSelection | undefined
+}
 export type OnRenderContextMenu = (
   items: ContextMenuItem[],
   context: RenderContextMenuContext
@@ -408,7 +410,7 @@ export type OnBlur = () => void
 export type OnSortModal = (props: SortModalCallback) => void
 export type OnTransformModal = (props: TransformModalCallback) => void
 export type OnJSONEditorModal = (props: JSONEditorModalCallback) => void
-export type FindNextInside = (path: JSONPath) => JSONSelection | null
+export type FindNextInside = (path: JSONPath) => JSONSelection | undefined
 
 export interface SearchResultDetails {
   items: ExtendedSearchResultItem[]
@@ -471,18 +473,18 @@ export interface HistoryItem {
     json: unknown | undefined
     text: string | undefined
     documentState: DocumentState | undefined
-    selection: JSONSelection | null
+    selection: JSONSelection | undefined
+    sortedColumn: SortedColumn | undefined
     textIsRepaired: boolean
-    sortedColumn: SortedColumn | null
   }
   redo: {
     patch: JSONPatchDocument | undefined
     json: unknown | undefined
     text: string | undefined
     documentState: DocumentState | undefined
-    selection: JSONSelection | null
+    selection: JSONSelection | undefined
+    sortedColumn: SortedColumn | undefined
     textIsRepaired: boolean
-    sortedColumn: SortedColumn | null
   }
 }
 
@@ -533,7 +535,7 @@ export interface JSONEditorPropsOptional {
   escapeUnicodeCharacters?: boolean
   flattenColumns?: boolean
   parser?: JSONParser
-  validator?: Validator | null
+  validator?: Validator | undefined
   validationParser?: JSONParser
   pathParser?: JSONPathParser
 
@@ -559,7 +561,7 @@ export interface JSONEditorContext {
   normalization: ValueNormalization
   getJson: () => unknown | undefined
   getDocumentState: () => DocumentState | undefined
-  findElement: (path: JSONPath) => Element | null
+  findElement: (path: JSONPath) => Element | undefined
   findNextInside: FindNextInside
   focus: () => void
   onPatch: OnPatch
@@ -572,8 +574,8 @@ export interface JSONEditorContext {
 export interface TreeModeContext extends JSONEditorContext {
   getJson: () => unknown | undefined
   getDocumentState: () => DocumentState | undefined
-  getSelection: () => JSONSelection | null
-  findElement: (path: JSONPath) => Element | null
+  getSelection: () => JSONSelection | undefined
+  findElement: (path: JSONPath) => Element | undefined
   onInsert: (type: InsertType) => void
   onExpand: (path: JSONPath, expanded: boolean, recursive?: boolean) => void
   onExpandSection: (path: JSONPath, section: Section) => void
@@ -588,7 +590,7 @@ export interface RenderValueProps {
   value: unknown
   readOnly: boolean
   enforceString: boolean
-  selection: JSONSelection | null
+  selection: JSONSelection | undefined
   searchResultItems: SearchResultItem[] | undefined
   isEditing: boolean
   parser: JSONParser

--- a/src/lib/utils/copyToClipboard.ts
+++ b/src/lib/utils/copyToClipboard.ts
@@ -1,4 +1,4 @@
-export default function copyToClipBoard(text: string): Promise<void> | void {
+export default function copyToClipBoard(text: string): Promise<void> {
   if (navigator.clipboard) {
     return navigator.clipboard.writeText(text)
   }
@@ -22,7 +22,11 @@ export default function copyToClipBoard(text: string): Promise<void> | void {
     } finally {
       document.body.removeChild(textarea)
     }
+
+    return Promise.resolve()
   } else {
     console.error('Copy failed.')
+
+    return Promise.resolve()
   }
 }

--- a/src/lib/utils/debug.ts
+++ b/src/lib/utils/debug.ts
@@ -62,6 +62,8 @@ function tryReadLocalStorage(key: string): string | undefined {
   } catch (error) {
     // we do nothing with the error, not needed in this specific case
   }
+
+  return undefined
 }
 
 /**

--- a/src/lib/utils/domUtils.ts
+++ b/src/lib/utils/domUtils.ts
@@ -195,7 +195,7 @@ export function findParent(
   element: Element,
   predicate: (element: Element) => boolean
 ): Element | undefined {
-  let e: Element | null = element
+  let e: Element | undefined = element
 
   while (e && !predicate(e)) {
     e = e.parentNode as Element
@@ -237,9 +237,9 @@ export function insertActiveElementContents(
     return
   }
 
-  const activeElement: HTMLElement | null = window.document.activeElement
+  const activeElement: HTMLElement | undefined = window.document.activeElement
     ? (window.document.activeElement as HTMLElement)
-    : null
+    : undefined
 
   if (activeElement && activeElement.isContentEditable) {
     activeElement.textContent = replaceContents ? text : activeElement.textContent + text
@@ -254,8 +254,8 @@ export function insertActiveElementContents(
  * Gets a DOM element's Window.  This is normally just the global `window`
  * variable, but if we opened a child window, it may be different.
  */
-export function getWindow(element: Element): Window | null {
-  return element && element.ownerDocument ? element.ownerDocument.defaultView : null
+export function getWindow(element: Element): Window | undefined {
+  return element?.ownerDocument?.defaultView ?? undefined
 }
 
 export function activeElementIsChildOf(element: Element) {
@@ -310,13 +310,13 @@ export function decodeDataPath(pathStr: string): JSONPath {
 /**
  * Find the data path of the given element. Traverses the parent nodes until find
  */
-export function getDataPathFromTarget(target: Element): JSONPath | null {
+export function getDataPathFromTarget(target: Element): JSONPath | undefined {
   const parent = findParent(target, (element) => {
     return element?.hasAttribute ? element.hasAttribute('data-path') : false
   })
 
-  const dataPath = parent?.getAttribute('data-path')
-  return dataPath ? decodeDataPath(dataPath) : null
+  const dataPath = parent?.getAttribute('data-path') ?? undefined
+  return dataPath ? decodeDataPath(dataPath) : undefined
 }
 
 /**
@@ -411,7 +411,7 @@ export interface EditableDivElement extends HTMLDivElement {
   cancel: () => void
 }
 
-export function isEditableDivRef(element: Element | null): element is EditableDivElement {
+export function isEditableDivRef(element: Element | undefined): element is EditableDivElement {
   return (
     !!element &&
     element.nodeName === 'DIV' &&

--- a/src/lib/utils/domUtils.ts
+++ b/src/lib/utils/domUtils.ts
@@ -201,7 +201,7 @@ export function findParent(
     e = e.parentNode as Element
   }
 
-  return e || undefined
+  return e
 }
 
 /**

--- a/src/lib/utils/jsonSchemaUtils.test.ts
+++ b/src/lib/utils/jsonSchemaUtils.test.ts
@@ -183,9 +183,9 @@ describe('jsonSchemaUtils', () => {
         }
       }
       let path = ['bar']
-      assert.strictEqual(findSchema(schema, {}, path), null)
+      assert.strictEqual(findSchema(schema, {}, path), undefined)
       path = ['foo', 'bar']
-      assert.strictEqual(findSchema(schema, {}, path), null)
+      assert.strictEqual(findSchema(schema, {}, path), undefined)
     })
 
     test('should find one of required properties', () => {
@@ -607,9 +607,9 @@ describe('jsonSchemaUtils', () => {
           }
         }
         let path = ['not-in-schema']
-        assert.strictEqual(findSchema(schema, {}, path), null)
+        assert.strictEqual(findSchema(schema, {}, path), undefined)
         path = ['levelOne', 'not-in-schema']
-        assert.strictEqual(findSchema(schema, {}, path), null)
+        assert.strictEqual(findSchema(schema, {}, path), undefined)
       })
 
       test('should return additionalProperties schema', () => {

--- a/src/lib/utils/jsonSchemaUtils.ts
+++ b/src/lib/utils/jsonSchemaUtils.ts
@@ -8,10 +8,10 @@ export function getJSONSchemaOptions(
   schema: JSONSchema,
   schemaDefinitions: JSONSchemaDefinitions | undefined,
   path: JSONPath
-): JSONSchemaEnum | null {
+): JSONSchemaEnum | undefined {
   const schemaForPath = findSchema(schema, schemaDefinitions || {}, path)
 
-  return schemaForPath ? findEnum(schemaForPath) : null
+  return schemaForPath ? findEnum(schemaForPath) : undefined
 }
 
 /**
@@ -20,7 +20,7 @@ export function getJSONSchemaOptions(
  *
  * Source: https://github.com/josdejong/jsoneditor/blob/develop/src/js/Node.js
  */
-export function findEnum(schema: JSONSchema): JSONSchemaEnum | null {
+export function findEnum(schema: JSONSchema): JSONSchemaEnum | undefined {
   if (Array.isArray(schema['enum'])) {
     return schema['enum']
   }
@@ -33,7 +33,7 @@ export function findEnum(schema: JSONSchema): JSONSchemaEnum | null {
     }
   }
 
-  return null
+  return undefined
 }
 
 /**
@@ -46,7 +46,7 @@ export function findSchema(
   schemaDefinitions: JSONSchemaDefinitions,
   path: JSONPath,
   currentSchema = topLevelSchema
-): JSONSchema | null {
+): JSONSchema | undefined {
   const nextPath = path.slice(1, path.length)
   const nextKey = path[0]
 
@@ -131,5 +131,5 @@ export function findSchema(
     }
   }
 
-  return null
+  return undefined
 }

--- a/src/lib/utils/jsonSchemaUtils.ts
+++ b/src/lib/utils/jsonSchemaUtils.ts
@@ -101,17 +101,14 @@ export function findSchema(
 
     if (
       typeof currentSchema.properties === 'object' &&
-      currentSchema.properties !== null &&
+      currentSchema.properties &&
       nextKey in currentSchema.properties
     ) {
       currentSchema = (currentSchema.properties as Record<string, JSONSchema>)[nextKey]
       return findSchema(topLevelSchema, schemaDefinitions, nextPath, currentSchema)
     }
 
-    if (
-      typeof currentSchema.patternProperties === 'object' &&
-      currentSchema.patternProperties !== null
-    ) {
+    if (typeof currentSchema.patternProperties === 'object' && currentSchema.patternProperties) {
       for (const prop in currentSchema.patternProperties) {
         if (nextKey.match(prop)) {
           currentSchema = (currentSchema.patternProperties as Record<string, JSONSchema>)[prop]
@@ -125,7 +122,7 @@ export function findSchema(
       return findSchema(topLevelSchema, schemaDefinitions, nextPath, currentSchema)
     }
 
-    if (typeof currentSchema.items === 'object' && currentSchema.items !== null) {
+    if (typeof currentSchema.items === 'object' && currentSchema.items) {
       currentSchema = currentSchema.items as JSONSchema
       return findSchema(topLevelSchema, schemaDefinitions, nextPath, currentSchema)
     }

--- a/src/lib/utils/jsonUtils.test.ts
+++ b/src/lib/utils/jsonUtils.test.ts
@@ -105,8 +105,8 @@ describe('jsonUtils', () => {
   })
 
   test('should validate content type', () => {
-    deepStrictEqual(validateContentType({ json: [1, 2, 3] }), null)
-    deepStrictEqual(validateContentType({ text: '[1,2,3]' }), null)
+    deepStrictEqual(validateContentType({ json: [1, 2, 3] }), undefined)
+    deepStrictEqual(validateContentType({ text: '[1,2,3]' }), undefined)
 
     deepStrictEqual(
       validateContentType({ text: [1, 2, 3] }),

--- a/src/lib/utils/jsonUtils.ts
+++ b/src/lib/utils/jsonUtils.ts
@@ -139,15 +139,17 @@ export function normalizeJsonParseError(jsonText: string, parseErrorMessage: str
   } else {
     // a message from Firefox, like "JSON.parse: expected property name or '}' at line 2 column 3 of the JSON data"
     const lineMatch = LINE_REGEX.exec(parseErrorMessage)
-    const lineOneBased = lineMatch ? int(lineMatch[1]) : null
-    const line = lineOneBased !== null ? lineOneBased - 1 : null
+    const lineOneBased = lineMatch ? int(lineMatch[1]) : undefined
+    const line = lineOneBased !== undefined ? lineOneBased - 1 : undefined
 
     const columnMatch = COLUMN_REGEX.exec(parseErrorMessage)
-    const columnOneBased = columnMatch ? int(columnMatch[1]) : null
-    const column = columnOneBased !== null ? columnOneBased - 1 : null
+    const columnOneBased = columnMatch ? int(columnMatch[1]) : undefined
+    const column = columnOneBased !== undefined ? columnOneBased - 1 : undefined
 
     const position =
-      line !== null && column !== null ? calculatePosition(jsonText, line, column) : null
+      line !== undefined && column !== undefined
+        ? calculatePosition(jsonText, line, column)
+        : undefined
 
     // line and column are one based in the message
     return {
@@ -165,7 +167,7 @@ export function normalizeJsonParseError(jsonText: string, parseErrorMessage: str
  * @param line     Zero-based line number
  * @param column   Zero-based column number
  */
-export function calculatePosition(text: string, line: number, column: number): number | null {
+export function calculatePosition(text: string, line: number, column: number): number | undefined {
   let index = text.indexOf('\n')
   let i = 1
 
@@ -176,7 +178,7 @@ export function calculatePosition(text: string, line: number, column: number): n
 
   return index !== -1
     ? index + column + 1 // +1 for the return character itself
-    : null
+    : undefined
 }
 
 export function countCharacterOccurrences(
@@ -319,7 +321,7 @@ export function convertValue(
  * Returns a string with validation error message when there is an issue,
  * or null otherwise
  */
-export function validateContentType(content: unknown): string | null {
+export function validateContentType(content: unknown): string | undefined {
   if (!isObject(content)) {
     return 'Content must be an object'
   }
@@ -328,7 +330,7 @@ export function validateContentType(content: unknown): string | null {
     if (content.text !== undefined) {
       return 'Content must contain either a property "json" or a property "text" but not both'
     } else {
-      return null
+      return undefined
     }
   } else {
     if (content.text === undefined) {
@@ -339,7 +341,7 @@ export function validateContentType(content: unknown): string | null {
         'Did you mean to use the "json" property instead?'
       )
     } else {
-      return null
+      return undefined
     }
   }
 }

--- a/src/lib/utils/jsonUtils.ts
+++ b/src/lib/utils/jsonUtils.ts
@@ -430,7 +430,7 @@ export function estimateSerializedSize(content: Content, maxSize = Infinity): nu
       estimatedSize += 2 + (json.length - 1)
 
       if (estimatedSize > maxSize) {
-        return estimatedSize
+        return
       }
 
       for (let i = 0; i < json.length; i++) {
@@ -439,7 +439,7 @@ export function estimateSerializedSize(content: Content, maxSize = Infinity): nu
         recurse(item)
 
         if (estimatedSize > maxSize) {
-          return estimatedSize
+          return
         }
       }
     } else if (isObject(json)) {

--- a/src/lib/utils/objectUtils.test.ts
+++ b/src/lib/utils/objectUtils.test.ts
@@ -53,6 +53,8 @@ describe('objectUtils', () => {
       }
 
       logs.push({ value, path: path.slice() })
+
+      return undefined
     })
 
     deepStrictEqual(logs, [

--- a/src/lib/utils/typeUtils.test.ts
+++ b/src/lib/utils/typeUtils.test.ts
@@ -133,10 +133,10 @@ describe('typeUtils', () => {
     expect(getColorCSS('#82b92c')).toBe('rgb(130,185,44)')
     expect(getColorCSS('rgba(255, 0, 0, 0.5)')).toBe('rgba(255,0,0,0.5)')
     expect(getColorCSS('#ff000066')).toBe('rgba(255,0,0,0.4)')
-    expect(getColorCSS('#a')).toBe(null)
-    expect(getColorCSS('foo')).toBe(null)
-    expect(getColorCSS('red  ')).toBe(null)
-    expect(getColorCSS('  ')).toBe(null)
+    expect(getColorCSS('#a')).toBe(undefined)
+    expect(getColorCSS('foo')).toBe(undefined)
+    expect(getColorCSS('red  ')).toBe(undefined)
+    expect(getColorCSS('  ')).toBe(undefined)
   })
 
   test('isColor', () => {

--- a/src/lib/utils/typeUtils.ts
+++ b/src/lib/utils/typeUtils.ts
@@ -84,16 +84,16 @@ export function isTimestamp(value: unknown): boolean {
  *
  * Source: https://stackoverflow.com/questions/6386090/validating-css-color-names/33184805
  */
-export function getColorCSS(color: string): string | null {
+export function getColorCSS(color: string): string | undefined {
   colorTestDiv = colorTestDiv || window.document.createElement('div')
 
   colorTestDiv.style.color = ''
   colorTestDiv.style.color = color
 
   const applied = colorTestDiv.style.color
-  return applied !== '' ? applied.replace(/\s+/g, '').toLowerCase() : null
+  return applied !== '' ? applied.replace(/\s+/g, '').toLowerCase() : undefined
 }
-let colorTestDiv: HTMLDivElement | null = null
+let colorTestDiv: HTMLDivElement | undefined = undefined
 
 /**
  * Test if a string contains a valid color name or code.

--- a/src/routes/development/+page.svelte
+++ b/src/routes/development/+page.svelte
@@ -93,8 +93,8 @@
     json: undefined
   }
 
-  let selectionTree: JSONEditorSelection | null = null
-  let selectionText: JSONEditorSelection | null = null
+  let selectionTree: JSONEditorSelection | undefined
+  let selectionText: JSONEditorSelection | undefined
 
   const schema = {
     title: 'Employee',
@@ -362,11 +362,11 @@
     })
   }
 
-  function onSelectTree(selection: JSONEditorSelection | null) {
+  function onSelectTree(selection: JSONEditorSelection | undefined) {
     console.log('onSelectTree', selection)
   }
 
-  function onSelectText(selection: JSONEditorSelection | null) {
+  function onSelectText(selection: JSONEditorSelection | undefined) {
     console.log('onSelectText', selection)
   }
 
@@ -695,8 +695,8 @@
     </button>
     <button
       on:click={() => {
-        refTreeEditor?.select(null)
-        refTextEditor?.select(null)
+        refTreeEditor?.select(undefined)
+        refTextEditor?.select(undefined)
       }}
     >
       Select nothing

--- a/src/routes/examples/custom_dynamic_styling/+page.svelte
+++ b/src/routes/examples/custom_dynamic_styling/+page.svelte
@@ -22,6 +22,8 @@
     if (value === true || value === false) {
       return 'custom-class-boolean'
     }
+
+    return undefined
   }
 </script>
 


### PR DESCRIPTION
Reason: the API currently has a mix of `null` and `undefined`. To unify this, we will use `undefined` everywhere. This works better than `null` since `undefined` is the "default" in JavaScript, for example with optional chainging, missing properties, empty array slots, function argument defaults. Also: `null` is a valid JSON value, so for the `Content.json` type we _must_ use `undefined` when there is no JSON.

This is a breaking change in the following properties and methods:

- `selection`
- `onChange` (`contentErrors` and `patchResult` properties)
- `onRenderContextMenu` (`selection` property)
- `onSelect`
- `validate` (returns `undefined`)
- `select`

