### PR TITLE
API for expand and collapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ editor.updateProps({
 JSONEditor.prototype.expand(path: JSONPath, callback?: (relativePath: JSONPath) => boolean = expandSelf): Promise<void>
 ```
 
-Expand or collapse paths in the editor. All nodes along the provided `path` will be expanded and become visible (rendered). So for example collapsed sections of an array will be expanded. Using the optional `callback`, the node itself and some or all of its nested child nodes can be expanded too. The `callback` function only iterates over the visible items of arrays and not over any of the collapsed items.
+Expand or collapse paths in the editor. All nodes along the provided `path` will be expanded and become visible (rendered). So for example collapsed sections of an array will be expanded. Using the optional `callback`, the node itself and some or all of its nested child nodes can be expanded too. The `callback` function only iterates over the visible sections of an array and not over any of the collapsed sections. By default, the first 100 items of an array are visible and rendered.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -735,10 +735,10 @@ The library exports a couple of utility functions for commonly used `callback` f
 ### collapse
 
 ```ts
-JSONEditor.prototype.collapse(path: JSONPath): Promise<void>
+JSONEditor.prototype.collapse(path: JSONPath, recursive?: boolean = false): Promise<void>
 ```
 
-Collapse a path in the editor. All nested objects and arrays will be collapsed too.
+Collapse a path in the editor. When `recursive` is `true`, all nested objects and arrays will be collapsed too. The default value of `recursive` is `false`.
 
 #### transform
 

--- a/README.md
+++ b/README.md
@@ -712,10 +712,12 @@ editor.updateProps({
 #### expand
 
 ```ts
-JSONEditor.prototype.expand([callback: (path: Path) => boolean]): Promise<void>
+JSONEditor.prototype.expand([callback: (path: Path, hidden: boolean) => boolean]): Promise<void>
 ```
 
-Expand or collapse paths in the editor. The `callback` determines which paths will be expanded. If no `callback` is provided, all paths will be expanded. It is only possible to expand a path when all of its parent paths are expanded too. Examples:
+Expand or collapse paths in the editor. The `callback` determines which paths will be expanded. If no `callback` is provided, all paths will be expanded. It is only possible to expand a path when all of its parent paths are expanded too. The second argument `hidden` of the callback is true for items in an array that are inside a collapsed part of the array: by default, only the first 100 items of an array are rendered.
+
+Examples:
 
 - `editor.expand(path => true)` expand all
 - `editor.expand(path => false)` collapse all

--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -217,8 +217,8 @@
     await tick() // await rerender
   }
 
-  export async function collapse(path: JSONPath): Promise<void> {
-    refJSONEditorRoot.collapse(path)
+  export async function collapse(path: JSONPath, recursive = false): Promise<void> {
+    refJSONEditorRoot.collapse(path, recursive)
 
     await tick() // await rerender
   }

--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -211,8 +211,14 @@
     await tick() // await rerender
   }
 
-  export async function expand(callback?: OnExpand): Promise<void> {
-    refJSONEditorRoot.expand(callback)
+  export async function expand(path: JSONPath, callback?: OnExpand): Promise<void> {
+    refJSONEditorRoot.expand(path, callback)
+
+    await tick() // await rerender
+  }
+
+  export async function collapse(path: JSONPath): Promise<void> {
+    refJSONEditorRoot.collapse(path)
 
     await tick() // await rerender
   }

--- a/src/lib/components/modes/JSONEditorRoot.svelte
+++ b/src/lib/components/modes/JSONEditorRoot.svelte
@@ -155,9 +155,9 @@
     }
   }
 
-  export function collapse(path: JSONPath): void {
+  export function collapse(path: JSONPath, recursive: boolean): void {
     if (refTreeMode) {
-      return refTreeMode.expand(path)
+      return refTreeMode.collapse(path, recursive)
     } else {
       throw new Error(`Method collapse is not available in mode "${mode}"`)
     }

--- a/src/lib/components/modes/JSONEditorRoot.svelte
+++ b/src/lib/components/modes/JSONEditorRoot.svelte
@@ -147,11 +147,19 @@
     throw new Error(`Method patch is not available in mode "${mode}"`)
   }
 
-  export function expand(callback?: OnExpand): void {
+  export function expand(path: JSONPath, callback?: OnExpand): void {
     if (refTreeMode) {
-      return refTreeMode.expand(callback)
+      return refTreeMode.expand(path, callback)
     } else {
       throw new Error(`Method expand is not available in mode "${mode}"`)
+    }
+  }
+
+  export function collapse(path: JSONPath): void {
+    if (refTreeMode) {
+      return refTreeMode.expand(path)
+    } else {
+      throw new Error(`Method collapse is not available in mode "${mode}"`)
     }
   }
 

--- a/src/lib/components/modes/tablemode/TableMode.svelte
+++ b/src/lib/components/modes/tablemode/TableMode.svelte
@@ -83,8 +83,6 @@
   import {
     createDocumentState,
     documentStatePatch,
-    expandMinimal,
-    expandWithCallback,
     getEnforceString,
     getInRecursiveState,
     setInDocumentState,
@@ -1369,12 +1367,7 @@
     const previousContent = { json, text }
     const previousState = { json, documentState, selection, sortedColumn, text, textIsRepaired }
 
-    const updatedState = expandWithCallback(
-      json,
-      syncDocumentState(updatedJson, documentState),
-      [],
-      expandMinimal
-    )
+    const updatedState = syncDocumentState(updatedJson, documentState)
 
     const callback =
       typeof afterPatch === 'function'
@@ -1411,24 +1404,14 @@
 
     try {
       json = parseMemoizeOne(updatedText)
-      documentState = expandWithCallback(
-        json,
-        syncDocumentState(json, documentState),
-        [],
-        expandMinimal
-      )
+      documentState = syncDocumentState(json, documentState)
       text = undefined
       textIsRepaired = false
       parseError = undefined
     } catch (err) {
       try {
         json = parseMemoizeOne(jsonrepair(updatedText))
-        documentState = expandWithCallback(
-          json,
-          syncDocumentState(json, documentState),
-          [],
-          expandMinimal
-        )
+        documentState = syncDocumentState(json, documentState)
         text = updatedText
         textIsRepaired = true
         parseError = undefined

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -330,8 +330,8 @@
     documentState = expandPath(json, documentState, path, callback)
   }
 
-  export function collapse(path: JSONPath) {
-    documentState = collapsePath(json, documentState, path)
+  export function collapse(path: JSONPath, recursive: boolean) {
+    documentState = collapsePath(json, documentState, path, recursive)
 
     if (selection) {
       // check whether the selection is still visible and not collapsed
@@ -1398,17 +1398,16 @@
   /**
    * Toggle expanded state of a node
    * @param path The path to be expanded
-   * @param expanded  True to expand, false to collapse
+   * @param expanded  True if currently expanded, false when currently collapsed
    * @param [recursive=false]  Only applicable when expanding
    */
   function handleExpand(path: JSONPath, expanded: boolean, recursive = false): void {
     debug('handleExpand', { path, expanded, recursive })
 
     if (expanded) {
-      const callback: OnExpand = recursive ? expandAll : (p) => p.length === 0
-      expand(path, callback)
+      expand(path, recursive ? expandAll : expandSelf)
     } else {
-      collapse(path)
+      collapse(path, recursive)
     }
 
     // set focus to the hidden input, so we can capture quick keys like Ctrl+X, Ctrl+C, Ctrl+V

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -32,7 +32,6 @@
     expandPath,
     expandRecursive,
     expandSection,
-    expandSingleItem,
     expandWithCallback,
     getDefaultExpand,
     getEnforceString,
@@ -1405,11 +1404,8 @@
     debug('handleExpand', { path, expanded, recursive })
 
     if (expanded) {
-      if (recursive) {
-        documentState = expandWithCallback(json, documentState, path, expandAll)
-      } else {
-        documentState = expandSingleItem(json, documentState, path)
-      }
+      const callback: OnExpand = recursive ? expandAll : (p) => p.length === path.length
+      documentState = expandWithCallback(json, documentState, path, callback)
     } else {
       documentState = collapsePath(json, documentState, path)
 

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -32,11 +32,9 @@
     expandSmart,
     expandSection,
     expandPath,
-    getSmartExpand,
     getEnforceString,
     setInDocumentState,
-    syncDocumentState,
-    updateInDocumentState
+    syncDocumentState
   } from '$lib/logic/documentState.js'
   import { createHistory } from '$lib/logic/history.js'
   import { duplicate, extract, revertJSONPatchWithMoveOperations } from '$lib/logic/operations.js'
@@ -510,7 +508,7 @@
   function expandWhenNotInitialized(json: unknown) {
     if (!documentStateInitialized) {
       documentStateInitialized = true
-      documentState = createDocumentState({ json, expand: getSmartExpand(json) })
+      documentState = expandSmart(json, documentState, [])
     }
   }
 

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -27,9 +27,9 @@
     collapsePath,
     createDocumentState,
     documentStatePatch,
-    expandAll,
+    expandAllNonHidden,
     expandMinimal,
-    expandPath,
+    expandParentPath,
     expandRecursive,
     expandSection,
     expandWithCallback,
@@ -300,7 +300,7 @@
   }
 
   async function handleFocusSearch(path: JSONPath) {
-    documentState = expandPath(json, documentState, path)
+    documentState = expandParentPath(json, documentState, path)
     await scrollTo(path)
   }
 
@@ -324,7 +324,7 @@
   })
   let historyState = history.getState()
 
-  export function expand(callback: OnExpand = expandAll) {
+  export function expand(callback: OnExpand = expandAllNonHidden) {
     debug('expand')
 
     // FIXME: clear the expanded state and visible sections (else you can't collapse anything using the callback)
@@ -1183,7 +1183,7 @@
    * Expand the path when needed.
    */
   export async function scrollTo(path: JSONPath, scrollToWhenVisible = true): Promise<void> {
-    documentState = expandPath(json, documentState, path)
+    documentState = expandParentPath(json, documentState, path)
     await tick() // await rerender (else the element we want to scroll to does not yet exist)
 
     const elem = findElement(path)
@@ -1404,7 +1404,7 @@
     debug('handleExpand', { path, expanded, recursive })
 
     if (expanded) {
-      const callback: OnExpand = recursive ? expandAll : (p) => p.length === path.length
+      const callback: OnExpand = recursive ? expandAllNonHidden : (p) => p.length === path.length
       documentState = expandWithCallback(json, documentState, path, callback)
     } else {
       documentState = collapsePath(json, documentState, path)

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -29,10 +29,10 @@
     documentStatePatch,
     expandAll,
     expandMinimal,
-    expandRecursive,
+    expandSmart,
     expandSection,
     expandPath,
-    getDefaultExpand,
+    getSmartExpand,
     getEnforceString,
     setInDocumentState,
     syncDocumentState,
@@ -510,7 +510,7 @@
   function expandWhenNotInitialized(json: unknown) {
     if (!documentStateInitialized) {
       documentStateInitialized = true
-      documentState = createDocumentState({ json, expand: getDefaultExpand(json) })
+      documentState = createDocumentState({ json, expand: getSmartExpand(json) })
     }
   }
 
@@ -842,7 +842,7 @@
         // expand extracted object/array
         const path: JSONPath = []
         return {
-          state: expandRecursive(patchedJson, patchedState, path)
+          state: expandSmart(patchedJson, patchedState, path)
         }
       }
 
@@ -910,7 +910,7 @@
         // expand converted object/array
         return {
           state: selection
-            ? expandRecursive(patchedJson, patchedState, getFocusPath(selection))
+            ? expandSmart(patchedJson, patchedState, getFocusPath(selection))
             : documentState
         }
       })
@@ -1073,7 +1073,7 @@
 
         handlePatch(operations, (patchedJson, patchedState) => ({
           // expand the newly replaced array and select it
-          state: expandRecursive(patchedJson, patchedState, rootPath),
+          state: expandSmart(patchedJson, patchedState, rootPath),
           selection: createValueSelection(rootPath, false)
         }))
       },
@@ -1127,7 +1127,7 @@
 
           handlePatch(operations, (patchedJson, patchedState) => ({
             // expand the newly replaced array and select it
-            state: expandRecursive(patchedJson, patchedState, rootPath),
+            state: expandSmart(patchedJson, patchedState, rootPath),
             selection: createValueSelection(rootPath, false)
           }))
         }
@@ -1395,9 +1395,7 @@
 
     if (expanded) {
       const callback: OnExpand = recursive ? expandAll : (p) => p.length === path.length
-      documentState = updateInDocumentState(json, documentState, path, (value, state) => {
-        return expandPath(value, state, [], callback)
-      })
+      documentState = expandPath(json, documentState, path, callback)
     } else {
       documentState = collapsePath(json, documentState, path)
 
@@ -1790,7 +1788,7 @@
 
     handlePatch(operations, (patchedJson, patchedState) => {
       return {
-        state: expandRecursive(patchedJson, patchedState, path)
+        state: expandSmart(patchedJson, patchedState, path)
       }
     })
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -34,6 +34,9 @@ export {
   estimateSerializedSize
 } from './utils/jsonUtils.js'
 
+// expand
+export { expandAll, expandMinimal, expandNone, expandSelf } from './logic/documentState'
+
 // selection
 export {
   isValueSelection,

--- a/src/lib/logic/actions.ts
+++ b/src/lib/logic/actions.ts
@@ -40,7 +40,7 @@ import {
   parsePath
 } from 'immutable-json-patch'
 import { isObject, isObjectOrArray } from '$lib/utils/typeUtils.js'
-import { expandAll, expandRecursive, expandPath } from '$lib/logic/documentState.js'
+import { expandAll, expandSmart, expandPath } from '$lib/logic/documentState.js'
 import { initial, isEmpty, last } from 'lodash-es'
 import { insertActiveElementContents } from '$lib/utils/domUtils.js'
 import { fromTableCellPosition, toTableCellPosition } from '$lib/logic/table.js'
@@ -153,7 +153,7 @@ export function onPaste({
           )
           .forEach((operation) => {
             const path = parsePath(json, operation.path)
-            updatedState = expandRecursive(patchedJson, updatedState, path)
+            updatedState = expandSmart(patchedJson, updatedState, path)
           })
 
         return {
@@ -168,7 +168,7 @@ export function onPaste({
         if (patchedJson) {
           const path: JSONPath = []
           return {
-            state: expandRecursive(patchedJson, patchedState, path)
+            state: expandSmart(patchedJson, patchedState, path)
           }
         }
 
@@ -506,7 +506,7 @@ export function onInsert({
 
     const path: JSONPath = []
     onReplaceJson(newValue, (patchedJson, patchedState) => ({
-      state: expandRecursive(patchedJson, patchedState, path),
+      state: expandSmart(patchedJson, patchedState, path),
       selection: isObjectOrArray(newValue)
         ? createInsideSelection(path)
         : createValueSelection(path, true)

--- a/src/lib/logic/actions.ts
+++ b/src/lib/logic/actions.ts
@@ -40,12 +40,7 @@ import {
   parsePath
 } from 'immutable-json-patch'
 import { isObject, isObjectOrArray } from '$lib/utils/typeUtils.js'
-import {
-  expandAllNonHidden,
-  expandParentPath,
-  expandRecursive,
-  expandWithCallback
-} from '$lib/logic/documentState.js'
+import { expandAll, expandRecursive, expandPath } from '$lib/logic/documentState.js'
 import { initial, isEmpty, last } from 'lodash-es'
 import { insertActiveElementContents } from '$lib/utils/domUtils.js'
 import { fromTableCellPosition, toTableCellPosition } from '$lib/logic/table.js'
@@ -476,7 +471,7 @@ export function onInsert({
 
         if (isObjectOrArray(newValue)) {
           return {
-            state: expandWithCallback(patchedJson, patchedState, path, expandAllNonHidden),
+            state: expandPath(patchedJson, patchedState, path, expandAll),
             selection: selectInside ? createInsideSelection(path) : patchedSelection
           }
         }
@@ -486,8 +481,7 @@ export function onInsert({
           const parent = !isEmpty(path) ? getIn(patchedJson, initial(path)) : undefined
 
           return {
-            // expandParentPath is invoked to make sure that visibleSections is extended when needed
-            state: expandParentPath(patchedJson, patchedState, path),
+            state: expandPath(patchedJson, patchedState, path),
             selection: isObject(parent)
               ? createKeySelection(path, true)
               : createValueSelection(path, true)

--- a/src/lib/logic/actions.ts
+++ b/src/lib/logic/actions.ts
@@ -40,7 +40,7 @@ import {
   parsePath
 } from 'immutable-json-patch'
 import { isObject, isObjectOrArray } from '$lib/utils/typeUtils.js'
-import { expandAll, expandSmart, expandPath } from '$lib/logic/documentState.js'
+import { expandAll, expandSmart, expandPath, expandNone } from '$lib/logic/documentState.js'
 import { initial, isEmpty, last } from 'lodash-es'
 import { insertActiveElementContents } from '$lib/utils/domUtils.js'
 import { fromTableCellPosition, toTableCellPosition } from '$lib/logic/table.js'
@@ -481,7 +481,7 @@ export function onInsert({
           const parent = !isEmpty(path) ? getIn(patchedJson, initial(path)) : undefined
 
           return {
-            state: expandPath(patchedJson, patchedState, path),
+            state: expandPath(patchedJson, patchedState, path, expandNone),
             selection: isObject(parent)
               ? createKeySelection(path, true)
               : createValueSelection(path, true)

--- a/src/lib/logic/actions.ts
+++ b/src/lib/logic/actions.ts
@@ -41,8 +41,8 @@ import {
 } from 'immutable-json-patch'
 import { isObject, isObjectOrArray } from '$lib/utils/typeUtils.js'
 import {
-  expandAll,
-  expandPath,
+  expandAllNonHidden,
+  expandParentPath,
   expandRecursive,
   expandWithCallback
 } from '$lib/logic/documentState.js'
@@ -476,7 +476,7 @@ export function onInsert({
 
         if (isObjectOrArray(newValue)) {
           return {
-            state: expandWithCallback(patchedJson, patchedState, path, expandAll),
+            state: expandWithCallback(patchedJson, patchedState, path, expandAllNonHidden),
             selection: selectInside ? createInsideSelection(path) : patchedSelection
           }
         }
@@ -486,8 +486,8 @@ export function onInsert({
           const parent = !isEmpty(path) ? getIn(patchedJson, initial(path)) : undefined
 
           return {
-            // expandPath is invoked to make sure that visibleSections is extended when needed
-            state: expandPath(patchedJson, patchedState, path),
+            // expandParentPath is invoked to make sure that visibleSections is extended when needed
+            state: expandParentPath(patchedJson, patchedState, path),
             selection: isObject(parent)
               ? createKeySelection(path, true)
               : createValueSelection(path, true)

--- a/src/lib/logic/documentState.test.ts
+++ b/src/lib/logic/documentState.test.ts
@@ -300,7 +300,6 @@ describe('documentState', () => {
             type: 'array',
             expanded: true,
             visibleSections: DEFAULT_VISIBLE_SECTIONS,
-            // eslint-disable-next-line no-sparse-arrays
             items: [{ type: 'value' }, { type: 'value' }, { type: 'value' }, { type: 'value' }]
           }
         ],
@@ -315,7 +314,6 @@ describe('documentState', () => {
             type: 'array',
             expanded: true,
             visibleSections: DEFAULT_VISIBLE_SECTIONS,
-            // eslint-disable-next-line no-sparse-arrays
             items: [{ type: 'value' }, { type: 'value' }, { type: 'value' }]
           }
         ],
@@ -327,7 +325,6 @@ describe('documentState', () => {
       const expected2: DocumentState = {
         type: 'array',
         expanded: true,
-        // eslint-disable-next-line no-sparse-arrays
         items: [],
         visibleSections: DEFAULT_VISIBLE_SECTIONS
       }
@@ -937,7 +934,6 @@ describe('documentState', () => {
           },
           members: {
             expanded: true,
-            // eslint-disable-next-line no-sparse-arrays
             items: [
               { expanded: true, properties: {}, type: 'object' },
               undefined, // ideally, this should be an empty item, not undefined

--- a/src/lib/logic/documentState.test.ts
+++ b/src/lib/logic/documentState.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest'
 import { flatMap, isEqual, range, times } from 'lodash-es'
 import { ARRAY_SECTION_SIZE, DEFAULT_VISIBLE_SECTIONS } from '../constants.js'
 import {
+  collapsePath,
   createArrayDocumentState,
   createDocumentState,
   createObjectDocumentState,
@@ -1680,6 +1681,86 @@ describe('documentState', () => {
           e: { expanded: true, properties: {}, type: 'object' }
         },
         type: 'object'
+      })
+    })
+  })
+
+  describe('collapsePath', () => {
+    const json = {
+      largeArray: range(0, 300).map((index) => ({ id: index }))
+    }
+
+    const documentState: DocumentState = {
+      type: 'object',
+      expanded: true,
+      properties: {
+        largeArray: {
+          type: 'array',
+          expanded: true,
+          items: initArray([120, { type: 'object', expanded: true, properties: {} }]),
+          visibleSections: [{ start: 0, end: 200 }]
+        }
+      }
+    }
+
+    test('collapse a path (recursive)', () => {
+      // TODO
+      assert.deepStrictEqual(collapsePath(json, documentState, [], true), {
+        type: 'object',
+        expanded: false,
+        properties: {
+          largeArray: {
+            type: 'array',
+            expanded: false,
+            items: initArray([120, { type: 'object', expanded: false, properties: {} }]),
+            visibleSections: [{ start: 0, end: 200 }]
+          }
+        }
+      })
+    })
+
+    test('collapse a path (non-recursive)', () => {
+      assert.deepStrictEqual(collapsePath(json, documentState, [], false), {
+        type: 'object',
+        expanded: false,
+        properties: {
+          largeArray: {
+            type: 'array',
+            expanded: true,
+            items: initArray([120, { type: 'object', expanded: true, properties: {} }]),
+            visibleSections: [{ start: 0, end: 200 }]
+          }
+        }
+      })
+    })
+
+    test('collapse a nested path (recursive)', () => {
+      assert.deepStrictEqual(collapsePath(json, documentState, ['largeArray'], true), {
+        type: 'object',
+        expanded: true,
+        properties: {
+          largeArray: {
+            type: 'array',
+            expanded: false,
+            items: initArray([120, { type: 'object', expanded: false, properties: {} }]),
+            visibleSections: [{ start: 0, end: 200 }]
+          }
+        }
+      })
+    })
+
+    test('collapse a nested path (non-recursive)', () => {
+      assert.deepStrictEqual(collapsePath(json, documentState, ['largeArray'], false), {
+        type: 'object',
+        expanded: true,
+        properties: {
+          largeArray: {
+            type: 'array',
+            expanded: false,
+            items: initArray([120, { type: 'object', expanded: true, properties: {} }]),
+            visibleSections: [{ start: 0, end: 200 }]
+          }
+        }
       })
     })
   })

--- a/src/lib/logic/documentState.test.ts
+++ b/src/lib/logic/documentState.test.ts
@@ -1690,6 +1690,7 @@ describe('documentState', () => {
       largeArray: range(0, 300).map((index) => ({ id: index }))
     }
 
+    const idState: DocumentState = { type: 'value', enforceString: true }
     const documentState: DocumentState = {
       type: 'object',
       expanded: true,
@@ -1697,14 +1698,20 @@ describe('documentState', () => {
         largeArray: {
           type: 'array',
           expanded: true,
-          items: initArray([120, { type: 'object', expanded: true, properties: {} }]),
+          items: initArray([
+            120,
+            {
+              type: 'object',
+              expanded: true,
+              properties: { id: idState }
+            }
+          ]),
           visibleSections: [{ start: 0, end: 200 }]
         }
       }
     }
 
     test('collapse a path (recursive)', () => {
-      // TODO
       assert.deepStrictEqual(collapsePath(json, documentState, [], true), {
         type: 'object',
         expanded: false,
@@ -1712,7 +1719,7 @@ describe('documentState', () => {
           largeArray: {
             type: 'array',
             expanded: false,
-            items: initArray([120, { type: 'object', expanded: false, properties: {} }]),
+            items: [],
             visibleSections: [{ start: 0, end: 100 }]
           }
         }
@@ -1727,7 +1734,10 @@ describe('documentState', () => {
           largeArray: {
             type: 'array',
             expanded: true,
-            items: initArray([120, { type: 'object', expanded: true, properties: {} }]),
+            items: initArray([
+              120,
+              { type: 'object', expanded: true, properties: { id: idState } }
+            ]),
             visibleSections: [{ start: 0, end: 200 }]
           }
         }
@@ -1742,7 +1752,7 @@ describe('documentState', () => {
           largeArray: {
             type: 'array',
             expanded: false,
-            items: initArray([120, { type: 'object', expanded: false, properties: {} }]),
+            items: [],
             visibleSections: [{ start: 0, end: 100 }]
           }
         }
@@ -1757,7 +1767,10 @@ describe('documentState', () => {
           largeArray: {
             type: 'array',
             expanded: false,
-            items: initArray([120, { type: 'object', expanded: true, properties: {} }]),
+            items: initArray([
+              120,
+              { type: 'object', expanded: true, properties: { id: idState } }
+            ]),
             visibleSections: [{ start: 0, end: 100 }]
           }
         }

--- a/src/lib/logic/documentState.test.ts
+++ b/src/lib/logic/documentState.test.ts
@@ -1713,7 +1713,7 @@ describe('documentState', () => {
             type: 'array',
             expanded: false,
             items: initArray([120, { type: 'object', expanded: false, properties: {} }]),
-            visibleSections: [{ start: 0, end: 200 }]
+            visibleSections: [{ start: 0, end: 100 }]
           }
         }
       })
@@ -1743,7 +1743,7 @@ describe('documentState', () => {
             type: 'array',
             expanded: false,
             items: initArray([120, { type: 'object', expanded: false, properties: {} }]),
-            visibleSections: [{ start: 0, end: 200 }]
+            visibleSections: [{ start: 0, end: 100 }]
           }
         }
       })
@@ -1758,7 +1758,7 @@ describe('documentState', () => {
             type: 'array',
             expanded: false,
             items: initArray([120, { type: 'object', expanded: true, properties: {} }]),
-            visibleSections: [{ start: 0, end: 200 }]
+            visibleSections: [{ start: 0, end: 100 }]
           }
         }
       })

--- a/src/lib/logic/documentState.test.ts
+++ b/src/lib/logic/documentState.test.ts
@@ -165,7 +165,7 @@ describe('documentState', () => {
         type: 'object',
         expanded: true,
         properties: {
-          c: { type: 'value', enforceString: false }
+          c: { type: 'value', enforceString: true }
         }
       }
       assert.deepStrictEqual(syncDocumentState({ a: 1, b: 2, c: 3 }, state), state)

--- a/src/lib/logic/documentState.test.ts
+++ b/src/lib/logic/documentState.test.ts
@@ -417,11 +417,11 @@ describe('documentState', () => {
       object: { a: 4, b: 5 },
       value: 'hello'
     }
-    const expandedState = createDocumentState({ json })
+    const documentState = createDocumentState({ json })
 
     test('should fully expand a json document', () => {
       assert.deepStrictEqual(
-        expandPath(json, expandedState, [], () => true),
+        expandPath(json, documentState, [], () => true),
         {
           type: 'object',
           expanded: true,
@@ -445,7 +445,7 @@ describe('documentState', () => {
 
     test('should expand a nested item of a json document', () => {
       assert.deepStrictEqual(
-        expandPath(json, expandedState, ['array'], (path) => isEqual(path, ['array'])),
+        expandPath(json, documentState, ['array'], (relativePath) => isEqual(relativePath, [])),
         {
           expanded: true,
           properties: {
@@ -463,7 +463,7 @@ describe('documentState', () => {
 
     test('should expand a nested item of a json document starting without state', () => {
       assert.deepStrictEqual(
-        expandPath(json, undefined, ['array'], (path) => isEqual(path, ['array'])),
+        expandPath(json, undefined, ['array'], (relativePath) => isEqual(relativePath, [])),
         {
           expanded: true,
           properties: {
@@ -481,7 +481,7 @@ describe('documentState', () => {
 
     test('should expand a part of a json document recursively', () => {
       assert.deepStrictEqual(
-        expandPath(json, expandedState, ['array'], () => true),
+        expandPath(json, documentState, ['array'], () => true),
         {
           expanded: true,
           properties: {
@@ -500,7 +500,7 @@ describe('documentState', () => {
 
     test('should partially expand a json document', () => {
       assert.deepStrictEqual(
-        expandPath(json, expandedState, [], (path) => path.length <= 1),
+        expandPath(json, documentState, [], (relativePath) => relativePath.length <= 1),
         {
           expanded: true,
           properties: {
@@ -519,7 +519,7 @@ describe('documentState', () => {
 
     test('should expand the root of a json document', () => {
       assert.deepStrictEqual(
-        expandPath(json, expandedState, [], (path) => path.length === 0),
+        expandPath(json, documentState, [], (relativePath) => relativePath.length === 0),
         {
           expanded: true,
           properties: {},
@@ -530,7 +530,7 @@ describe('documentState', () => {
 
     test('should not traverse non-expanded nodes', () => {
       assert.deepStrictEqual(
-        expandPath(json, expandedState, [], (path) => path.length > 0),
+        expandPath(json, documentState, [], (relativePath) => relativePath.length > 0),
         {
           expanded: false,
           properties: {},

--- a/src/lib/logic/documentState.test.ts
+++ b/src/lib/logic/documentState.test.ts
@@ -1763,6 +1763,42 @@ describe('documentState', () => {
         }
       })
     })
+
+    test('collapse should do nothing on a non-existing path (1)', () => {
+      const nonExpandedState: DocumentState = {
+        type: 'object',
+        expanded: false,
+        properties: {}
+      }
+
+      assert.deepStrictEqual(collapsePath(json, nonExpandedState, [], false), {
+        type: 'object',
+        expanded: false,
+        properties: {}
+      })
+    })
+
+    test('collapse should do nothing on a non-existing path (2)', () => {
+      const nonExpandedState: DocumentState = {
+        type: 'object',
+        expanded: false,
+        properties: {}
+      }
+
+      // TODO: it would be more neat if the documentState was left untouched since it is not collapsed anyway
+      assert.deepStrictEqual(collapsePath(json, nonExpandedState, ['largeArray'], false), {
+        type: 'object',
+        expanded: false,
+        properties: {
+          largeArray: {
+            expanded: false,
+            items: [],
+            type: 'array',
+            visibleSections: DEFAULT_VISIBLE_SECTIONS
+          }
+        }
+      })
+    })
   })
 })
 

--- a/src/lib/logic/documentState.ts
+++ b/src/lib/logic/documentState.ts
@@ -855,8 +855,11 @@ export function expandSmart(
   path: JSONPath
 ): DocumentState | undefined {
   const expandedJson = getIn(json, path)
+  const callback = isLargeContent({ json: expandedJson }, MAX_DOCUMENT_SIZE_EXPAND_ALL)
+    ? expandMinimal
+    : expandAll
 
-  return expandPath(json, documentState, path, getSmartExpand(expandedJson))
+  return expandPath(json, documentState, path, callback)
 }
 
 // TODO: write unit test
@@ -868,9 +871,4 @@ export function expandMinimal(path: JSONPath): boolean {
 // TODO: write unit test
 export function expandAll(): boolean {
   return true
-}
-
-// TODO: write unit test
-export function getSmartExpand(json: unknown): OnExpand {
-  return isLargeContent({ json }, MAX_DOCUMENT_SIZE_EXPAND_ALL) ? expandMinimal : expandAll
 }

--- a/src/lib/logic/documentState.ts
+++ b/src/lib/logic/documentState.ts
@@ -829,27 +829,27 @@ export function getNextVisiblePath(
  * Expand recursively when the expanded contents is small enough,
  * else expand in a minimalistic way
  */
-// TODO: write unit test
 export function expandSmart(
   json: unknown | undefined,
   documentState: DocumentState | undefined,
-  path: JSONPath
+  path: JSONPath,
+  maxSize: number = MAX_DOCUMENT_SIZE_EXPAND_ALL
 ): DocumentState | undefined {
-  const expandedJson = getIn(json, path)
-  const callback = isLargeContent({ json: expandedJson }, MAX_DOCUMENT_SIZE_EXPAND_ALL)
-    ? expandMinimal
-    : expandAll
+  const nestedJson = getIn(json, path)
+  const callback = isLargeContent({ json: nestedJson }, maxSize) ? expandMinimal : expandAll
 
   return expandPath(json, documentState, path, callback)
 }
 
-// TODO: write unit test
 export function expandMinimal(relativePath: JSONPath): boolean {
   // first item of an array
   return relativePath.length === 0 ? true : relativePath.length === 1 && relativePath[0] === '0'
 }
 
-// TODO: write unit test
+export function expandSelf(relativePath: JSONPath): boolean {
+  return relativePath.length === 0
+}
+
 export function expandAll(): boolean {
   return true
 }

--- a/src/lib/logic/documentState.ts
+++ b/src/lib/logic/documentState.ts
@@ -272,7 +272,7 @@ export function expandPath(
   json: unknown | undefined,
   documentState: DocumentState | undefined,
   path: JSONPath,
-  expandedCallback?: OnExpand
+  callback: OnExpand
 ): DocumentState | undefined {
   let updatedState = documentState
 
@@ -295,14 +295,10 @@ export function expandPath(
     })
   }
 
-  if (!expandedCallback) {
-    return updatedState
-  }
-
   // Step 2: recursively expand child nodes tested with the callback
   return updateInDocumentState(json, updatedState, path, (nestedValue, nestedState) => {
     const relativePath: JSONPath = []
-    return _expandRecursively(nestedValue, nestedState, relativePath, expandedCallback)
+    return _expandRecursively(nestedValue, nestedState, relativePath, callback)
   })
 }
 
@@ -841,15 +837,25 @@ export function expandSmart(
   return expandPath(json, documentState, path, callback)
 }
 
+/**
+ * Expand the root array or object, and in case of an array, expand the first array item
+ */
 export function expandMinimal(relativePath: JSONPath): boolean {
   // first item of an array
   return relativePath.length === 0 ? true : relativePath.length === 1 && relativePath[0] === '0'
 }
 
+/**
+ * Expand the root array or object
+ */
 export function expandSelf(relativePath: JSONPath): boolean {
   return relativePath.length === 0
 }
 
 export function expandAll(): boolean {
   return true
+}
+
+export function expandNone(): boolean {
+  return false
 }

--- a/src/lib/logic/selection.test.ts
+++ b/src/lib/logic/selection.test.ts
@@ -16,6 +16,7 @@ import {
   getSelectionRight,
   getSelectionUp,
   pathInSelection,
+  pathStartsWith,
   selectionIfOverlapping,
   selectionToPartialJson
 } from './selection.js'
@@ -884,6 +885,19 @@ describe('selection', () => {
       assert.strictEqual(pathInSelection(json, selection, ['str']), false)
       assert.strictEqual(pathInSelection(json, selection, ['bool']), false)
       assert.strictEqual(pathInSelection(json, selection, ['obj', 'arr', '1']), true)
+    })
+  })
+
+  describe('pathStartsWith', () => {
+    test('should determine whether a path starts with parent path', () => {
+      assert.strictEqual(pathStartsWith([], []), true)
+      assert.strictEqual(pathStartsWith(['a'], []), true)
+      assert.strictEqual(pathStartsWith(['a'], ['a']), true)
+      assert.strictEqual(pathStartsWith(['a', 'b'], ['a']), true)
+      assert.strictEqual(pathStartsWith(['a', 'b'], ['a', 'b']), true)
+      assert.strictEqual(pathStartsWith(['a'], ['a', 'b']), false)
+      assert.strictEqual(pathStartsWith(['a', 'b'], ['b']), false)
+      assert.strictEqual(pathStartsWith(['a', 'b'], ['a', 'b', 'c']), false)
     })
   })
 })

--- a/src/lib/logic/selection.ts
+++ b/src/lib/logic/selection.ts
@@ -593,7 +593,6 @@ export function findRootPath(json: unknown, selection: JSONSelection): JSONPath 
     : initial(getFocusPath(selection)) // the parent path of the paths
 }
 
-// TODO: unit test
 export function pathStartsWith(path: JSONPath, parentPath: JSONPath): boolean {
   if (path.length < parentPath.length) {
     return false

--- a/src/lib/logic/selection.ts
+++ b/src/lib/logic/selection.ts
@@ -294,7 +294,7 @@ export function getSelectionDown(
   // if the focusPath is an Array or object, we must not step into it but
   // over it, we pass state with this array/object collapsed
   const collapsedState = isObjectOrArray(getIn(json, focusPath))
-    ? collapsePath(json, documentState, focusPath)
+    ? collapsePath(json, documentState, focusPath, true)
     : documentState
 
   const nextPath = getNextVisiblePath(json, documentState, focusPath)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -384,7 +384,7 @@ export type OnSort = (params: {
 export type OnFind = (findAndReplace: boolean) => void
 export type OnPaste = (pastedText: string) => void
 export type OnPasteJson = (pastedJson: { path: JSONPath; contents: unknown }) => void
-export type OnExpand = (path: JSONPath) => boolean
+export type OnExpand = (relativePath: JSONPath) => boolean
 export type OnRenderValue = (props: RenderValueProps) => RenderValueComponentDescription[]
 export type OnClassName = (path: JSONPath, value: unknown) => string | undefined
 export type OnChangeMode = (mode: Mode) => void

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -384,7 +384,7 @@ export type OnSort = (params: {
 export type OnFind = (findAndReplace: boolean) => void
 export type OnPaste = (pastedText: string) => void
 export type OnPasteJson = (pastedJson: { path: JSONPath; contents: unknown }) => void
-export type OnExpand = (path: JSONPath, hidden: boolean) => boolean
+export type OnExpand = (path: JSONPath) => boolean
 export type OnRenderValue = (props: RenderValueProps) => RenderValueComponentDescription[]
 export type OnClassName = (path: JSONPath, value: unknown) => string | undefined
 export type OnChangeMode = (mode: Mode) => void

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -384,7 +384,7 @@ export type OnSort = (params: {
 export type OnFind = (findAndReplace: boolean) => void
 export type OnPaste = (pastedText: string) => void
 export type OnPasteJson = (pastedJson: { path: JSONPath; contents: unknown }) => void
-export type OnExpand = (path: JSONPath) => boolean
+export type OnExpand = (path: JSONPath, hidden: boolean) => boolean
 export type OnRenderValue = (props: RenderValueProps) => RenderValueComponentDescription[]
 export type OnClassName = (path: JSONPath, value: unknown) => string | undefined
 export type OnChangeMode = (mode: Mode) => void


### PR DESCRIPTION
Implements a solution for https://github.com/josdejong/svelte-jsoneditor/discussions/249

Initially I've tried to make the existing `expand` method more flexible, but it turns out there are a couple different use cases that can't be supported in an easy way by a single callback function, and the expand and collapse functionality is not symmetric. So, I ended up implementing 4 use cases in two methods:

```ts
// expand all nodes along the path, and update the visible sections of an array if needed 
// (for example used by `editor.scrollTo`)
editor.expand(path: JSONPath)

// expand all nodes along the path, and recursively expand part or all of the nested children inside the node 
// depending on the callback (used on Ctrl+Click on an expand button)
editor.expand(path: JSONPath, callback: (relativePath: JSONPath) => boolean)

// collapse a single node at the path 
// does not collapse parent nodes along the path, and does not collapse nested children
editor.collapse(path: JSONPath)

// collapse a single node at the path and collapse all of its children when recursive is true
editor.collapse(path: JSONPath, recursive: boolean)
```

Note that this is a breaking change, and will be merged in the `v1` branch.