### PR TITLE
Revert "fix: text mode loads partially scrolled down"

### DIFF
--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -618,8 +618,7 @@
 
     codeMirrorView = new EditorView({
       state,
-      parent: target,
-      scrollTo: EditorView.scrollIntoView(0) // see https://discuss.codemirror.net/t/editor-starts-partially-scrolled-down/7567
+      parent: target
     })
 
     return codeMirrorView


### PR DESCRIPTION
Hello jos,

I think the commit 56e18ee0573e4af7731a725133e93dc179e2857e caused this issue: https://github.com/cloydlau/json-editor-vue/issues/95

Reproduction:

```js
<script>
import { JSONEditor } from '../../../lib/index.ts'

let show = true
</script>

<button on:click={() => { show = !show }}>Toggle Visibility: { show }</button>
<div style="height: 100vh;" />
{#if show}
  <JSONEditor mode="text" />
{/if}
```

<img width="814" alt="image" src="https://github.com/user-attachments/assets/a175345c-ef41-4d23-af74-f1bd29c4776a">