### PR TITLE
Maintain history when switching mode

### DIFF
--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -287,6 +287,9 @@
         case 'content':
           content = props[name] ?? contentDefault
           break
+        case 'selection':
+          selection = props[name] ?? selectionDefault
+          break
         case 'readOnly':
           readOnly = props[name] ?? readOnlyDefault
           break

--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -527,7 +527,7 @@
     {#key instanceId}
       <JSONEditorRoot
         bind:this={refJSONEditorRoot}
-        {mode}
+        externalMode={mode}
         {content}
         {selection}
         {readOnly}

--- a/src/lib/components/modals/JSONEditorModal.svelte
+++ b/src/lib/components/modals/JSONEditorModal.svelte
@@ -245,7 +245,7 @@
         <div class="jse-modal-inline-editor">
           <JSONEditorRoot
             bind:this={refEditor}
-            mode={currentState.mode}
+            externalMode={currentState.mode}
             content={currentState.content}
             selection={currentState.selection}
             {readOnly}

--- a/src/lib/components/modals/TransformModal.svelte
+++ b/src/lib/components/modals/TransformModal.svelte
@@ -17,6 +17,8 @@
   import TreeMode from '../modes/treemode/TreeMode.svelte'
   import type {
     Content,
+    HistoryItem,
+    History,
     JSONParser,
     JSONPathParser,
     OnChangeQueryLanguage,
@@ -31,6 +33,7 @@
   import { readonlyProxy } from '$lib/utils/readonlyProxy.js'
   import Modal from './Modal.svelte'
   import { onMount } from 'svelte'
+  import { createHistoryInstance } from '$lib/logic/history'
 
   const debug = createDebug('jsoneditor:TransformModal')
 
@@ -59,6 +62,12 @@
   export let onClose: () => void
 
   let refQueryInput: HTMLTextAreaElement
+
+  const historyInstance = createHistoryInstance<HistoryItem>({
+    onChange: (updatedHistory) => (history = updatedHistory)
+  })
+
+  let history: History<HistoryItem> = historyInstance.get()
 
   let selectedJson: unknown | undefined
   $: selectedJson = readonlyProxy(getIn(json, rootPath))
@@ -316,6 +325,7 @@
                 <TreeMode
                   externalContent={selectedContent}
                   externalSelection={undefined}
+                  {history}
                   readOnly={true}
                   mainMenuBar={false}
                   navigationBar={false}
@@ -351,6 +361,7 @@
                 <TreeMode
                   externalContent={previewContent}
                   externalSelection={undefined}
+                  {history}
                   readOnly={true}
                   mainMenuBar={false}
                   navigationBar={false}

--- a/src/lib/components/modals/TransformModal.svelte
+++ b/src/lib/components/modals/TransformModal.svelte
@@ -341,6 +341,8 @@
                   onChange={noop}
                   onChangeMode={noop}
                   onSelect={noop}
+                  onUndo={noop}
+                  onRedo={noop}
                   onFocus={noop}
                   onBlur={noop}
                   onSortModal={noop}
@@ -377,6 +379,8 @@
                   onChange={noop}
                   onChangeMode={noop}
                   onSelect={noop}
+                  onUndo={noop}
+                  onRedo={noop}
                   onFocus={noop}
                   onBlur={noop}
                   onSortModal={noop}

--- a/src/lib/components/modes/JSONEditorRoot.svelte
+++ b/src/lib/components/modes/JSONEditorRoot.svelte
@@ -101,6 +101,11 @@
       redo: { mode: externalMode, selection: undefined }
     }
 
+    if (mode === 'text' && refTextMode) {
+      // flush pending changes before adding a new history item
+      refTextMode.flush()
+    }
+
     debug('add history item', item)
     history.add(item)
 
@@ -117,7 +122,7 @@
       const items = history.items()
       const index = items.findIndex((i) => i === item)
       const prevItem = index !== -1 ? items[index - 1] : undefined
-      console.log('handleUndo', { index, item, items, prevItem })
+      debug('handleUndo', { index, item, items, prevItem })
       if (prevItem) {
         selection = prevItem.redo.selection
       }
@@ -135,7 +140,7 @@
       const items = history.items()
       const index = items.findIndex((i) => i === item)
       const nextItem = index !== -1 ? items[index + 1] : undefined
-      console.log('handleRedo', { index, item, items, nextItem })
+      debug('handleRedo', { index, item, items, nextItem })
       if (nextItem) {
         selection = nextItem.undo.selection
       }

--- a/src/lib/components/modes/JSONEditorRoot.svelte
+++ b/src/lib/components/modes/JSONEditorRoot.svelte
@@ -3,6 +3,8 @@
     Content,
     ContentErrors,
     ContextMenuItem,
+    HistoryItem,
+    HistoryRoot,
     JSONEditorSelection,
     JSONParser,
     JSONPatchResult,
@@ -35,6 +37,7 @@
   import type { JSONPatchDocument, JSONPath } from 'immutable-json-patch'
   import { isMenuSpace } from '$lib/typeguards.js'
   import { cloneDeep } from 'lodash-es'
+  import { createHistory } from '$lib/logic/history'
 
   export let content: Content
   export let selection: JSONEditorSelection | undefined
@@ -74,6 +77,23 @@
   let refTreeMode: TreeMode | undefined
   let refTableMode: TableMode | undefined
   let refTextMode: TextMode | undefined
+
+  const historyInstance = createHistory<HistoryItem>({
+    onChange: () => {
+      history = updateHistoryRoot()
+    }
+  })
+
+  function updateHistoryRoot(): HistoryRoot<HistoryItem> {
+    return {
+      ...historyInstance.getState(),
+      add: historyInstance.add,
+      undo: historyInstance.undo,
+      redo: historyInstance.redo
+    }
+  }
+
+  let history: HistoryRoot<HistoryItem> = updateHistoryRoot()
 
   let modeMenuItems: MenuItem[]
   $: modeMenuItems = [
@@ -268,6 +288,7 @@
     bind:this={refTextMode}
     externalContent={content}
     externalSelection={selection}
+    {history}
     {readOnly}
     {indentation}
     {tabSize}
@@ -293,6 +314,7 @@
     bind:this={refTableMode}
     externalContent={content}
     externalSelection={selection}
+    {history}
     {readOnly}
     {mainMenuBar}
     {escapeControlCharacters}
@@ -321,6 +343,7 @@
     bind:this={refTreeMode}
     externalContent={content}
     externalSelection={selection}
+    {history}
     {readOnly}
     {indentation}
     {mainMenuBar}

--- a/src/lib/components/modes/JSONEditorRoot.svelte
+++ b/src/lib/components/modes/JSONEditorRoot.svelte
@@ -4,7 +4,7 @@
     ContentErrors,
     ContextMenuItem,
     HistoryItem,
-    HistoryRoot,
+    History,
     JSONEditorSelection,
     JSONParser,
     JSONPatchResult,
@@ -37,7 +37,7 @@
   import type { JSONPatchDocument, JSONPath } from 'immutable-json-patch'
   import { isMenuSpace } from '$lib/typeguards.js'
   import { cloneDeep } from 'lodash-es'
-  import { createHistory } from '$lib/logic/history'
+  import { createHistoryInstance } from '$lib/logic/history'
 
   export let content: Content
   export let selection: JSONEditorSelection | undefined
@@ -78,22 +78,11 @@
   let refTableMode: TableMode | undefined
   let refTextMode: TextMode | undefined
 
-  const historyInstance = createHistory<HistoryItem>({
-    onChange: () => {
-      history = updateHistoryRoot()
-    }
+  const historyInstance = createHistoryInstance<HistoryItem>({
+    onChange: (updatedHistory) => (history = updatedHistory)
   })
 
-  function updateHistoryRoot(): HistoryRoot<HistoryItem> {
-    return {
-      ...historyInstance.getState(),
-      add: historyInstance.add,
-      undo: historyInstance.undo,
-      redo: historyInstance.redo
-    }
-  }
-
-  let history: HistoryRoot<HistoryItem> = updateHistoryRoot()
+  let history: History<HistoryItem> = historyInstance.get()
 
   let modeMenuItems: MenuItem[]
   $: modeMenuItems = [

--- a/src/lib/components/modes/tablemode/TableMode.svelte
+++ b/src/lib/components/modes/tablemode/TableMode.svelte
@@ -10,7 +10,7 @@
     ContextMenuItem,
     DocumentState,
     HistoryItem,
-    HistoryRoot,
+    History,
     JSONEditorContext,
     JSONEditorSelection,
     JSONParser,
@@ -165,7 +165,7 @@
   export let readOnly: boolean
   export let externalContent: Content
   export let externalSelection: JSONEditorSelection | undefined
-  export let history: HistoryRoot<HistoryItem>
+  export let history: History<HistoryItem>
   export let mainMenuBar: boolean
   export let escapeControlCharacters: boolean
   export let escapeUnicodeCharacters: boolean

--- a/src/lib/components/modes/tablemode/TableMode.svelte
+++ b/src/lib/components/modes/tablemode/TableMode.svelte
@@ -9,8 +9,8 @@
     ContentErrors,
     ContextMenuItem,
     DocumentState,
-    HistoryItem,
     History,
+    HistoryItem,
     JSONEditorContext,
     JSONEditorSelection,
     JSONParser,
@@ -22,12 +22,14 @@
     OnChangeMode,
     OnFocus,
     OnJSONEditorModal,
+    OnRedo,
     OnRenderContextMenuInternal,
     OnRenderMenuInternal,
     OnRenderValue,
     OnSelect,
     OnSortModal,
     OnTransformModal,
+    OnUndo,
     ParseError,
     PastedJson,
     SearchResultDetails,
@@ -178,6 +180,8 @@
   export let onChange: OnChange
   export let onChangeMode: OnChangeMode
   export let onSelect: OnSelect
+  export let onUndo: OnUndo
+  export let onRedo: OnRedo
   export let onRenderValue: OnRenderValue
   export let onRenderMenu: OnRenderMenuInternal
   export let onRenderContextMenu: OnRenderContextMenuInternal
@@ -340,9 +344,17 @@
 
   let documentState: DocumentState | undefined =
     json !== undefined ? createDocumentState({ json }) : undefined
-  let selection: JSONSelection | undefined
+  let selection: JSONSelection | undefined = isJSONSelection(externalSelection)
+    ? externalSelection
+    : undefined
   let sortedColumn: SortedColumn | undefined
   let textIsRepaired = false
+
+  onMount(() => {
+    if (selection) {
+      scrollIntoView(getFocusPath(selection))
+    }
+  })
 
   function onSortByHeader(newSortedColumn: SortedColumn) {
     if (readOnly) {
@@ -1589,6 +1601,7 @@
 
     const item = history.undo()
     if (!isTreeHistoryItem(item)) {
+      onUndo(item)
       return
     }
 
@@ -1633,6 +1646,7 @@
 
     const item = history.redo()
     if (!isTreeHistoryItem(item)) {
+      onRedo(item)
       return
     }
 

--- a/src/lib/components/modes/tablemode/menu/TableMenu.svelte
+++ b/src/lib/components/modes/tablemode/menu/TableMenu.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import type { MenuItem, OnRenderMenuInternal } from '$lib/types'
+  import type { HistoryItem, HistoryRoot, MenuItem, OnRenderMenuInternal } from '$lib/types'
   import Menu from '../../../controls/Menu.svelte'
   import {
     faEllipsisV,
@@ -11,13 +11,12 @@
     faSortAmountDownAlt,
     faUndo
   } from '@fortawesome/free-solid-svg-icons'
-  import type { HistoryState } from '$lib/logic/history'
   import { CONTEXT_MENU_EXPLANATION } from '$lib/constants.js'
 
   export let containsValidArray: boolean
   export let readOnly: boolean
   export let showSearch = false
-  export let historyState: HistoryState
+  export let history: HistoryRoot<HistoryItem>
   export let onSort: () => void
   export let onTransform: () => void
   export let onContextMenu: (event: MouseEvent) => void
@@ -72,7 +71,7 @@
           title: 'Undo (Ctrl+Z)',
           className: 'jse-undo',
           onClick: onUndo,
-          disabled: !historyState.canUndo
+          disabled: !history.canUndo
         },
         {
           type: 'button',
@@ -80,7 +79,7 @@
           title: 'Redo (Ctrl+Shift+Z)',
           className: 'jse-redo',
           onClick: onRedo,
-          disabled: !historyState.canRedo
+          disabled: !history.canRedo
         },
         {
           type: 'space'

--- a/src/lib/components/modes/tablemode/menu/TableMenu.svelte
+++ b/src/lib/components/modes/tablemode/menu/TableMenu.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import type { HistoryItem, HistoryRoot, MenuItem, OnRenderMenuInternal } from '$lib/types'
+  import type { HistoryItem, History, MenuItem, OnRenderMenuInternal } from '$lib/types'
   import Menu from '../../../controls/Menu.svelte'
   import {
     faEllipsisV,
@@ -16,7 +16,7 @@
   export let containsValidArray: boolean
   export let readOnly: boolean
   export let showSearch = false
-  export let history: HistoryRoot<HistoryItem>
+  export let history: History<HistoryItem>
   export let onSort: () => void
   export let onTransform: () => void
   export let onContextMenu: (event: MouseEvent) => void

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -178,7 +178,7 @@
     }
   })
 
-  let customHistoryAnnotation = Annotation.define()
+  let historyAnnotation = Annotation.define()
 
   let historyUpdatesQueue: ViewUpdate[] | null = null
 
@@ -501,7 +501,7 @@
     }
 
     codeMirrorView.dispatch({
-      annotations: customHistoryAnnotation.of('undo'),
+      annotations: historyAnnotation.of('undo'),
       changes: ChangeSet.fromJSON(item.undo.changes),
       selection: EditorSelection.fromJSON(item.undo.selection),
       scrollIntoView: true
@@ -528,7 +528,7 @@
     }
 
     codeMirrorView.dispatch({
-      annotations: customHistoryAnnotation.of('redo'),
+      annotations: historyAnnotation.of('redo'),
       changes: ChangeSet.fromJSON(item.redo.changes),
       selection: EditorSelection.fromJSON(item.redo.selection),
       scrollIntoView: true
@@ -682,9 +682,9 @@
           editorState = update.state
 
           if (update.docChanged) {
-            const isCustomHistoryEvent = update.transactions.some((transaction) => {
-              return !!transaction.annotation(customHistoryAnnotation)
-            })
+            const isCustomHistoryEvent = update.transactions.some(
+              (transaction) => !!transaction.annotation(historyAnnotation)
+            )
 
             if (!isCustomHistoryEvent) {
               historyUpdatesQueue = [...(historyUpdatesQueue ?? []), update]

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -88,7 +88,7 @@
     Content,
     ContentErrors,
     HistoryItem,
-    HistoryRoot,
+    History,
     JSONEditorSelection,
     JSONParser,
     JSONPatchResult,
@@ -129,7 +129,7 @@
   export let askToFormat: boolean
   export let externalContent: Content
   export let externalSelection: JSONEditorSelection | undefined
-  export let history: HistoryRoot<HistoryItem>
+  export let history: History<HistoryItem>
   export let indentation: number | string
   export let tabSize: number
   export let escapeUnicodeCharacters: boolean

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -681,8 +681,6 @@
         EditorView.updateListener.of((update) => {
           editorState = update.state
 
-          debug('update', update.docChanged, update.selectionSet, update)
-
           if (update.docChanged) {
             const isCustomHistoryEvent = update.transactions.some((transaction) => {
               return !!transaction.annotation(customHistoryAnnotation)

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -102,6 +102,7 @@
     ParseError,
     RichValidationError,
     TextHistoryItem,
+    TextSelection,
     TransformModalOptions,
     ValidationError,
     Validator
@@ -198,11 +199,11 @@
     const item: TextHistoryItem = {
       undo: {
         changes: inverseChanges.toJSON(),
-        selection: startState.selection.toJSON()
+        selection: toTextSelection(startState.selection)
       },
       redo: {
         changes: mergedChanges.toJSON(),
-        selection: endState.selection.toJSON()
+        selection: toTextSelection(endState.selection)
       }
     }
 
@@ -638,7 +639,7 @@
     const state = EditorState.create({
       doc: initialText,
       selection: isValidSelection(externalSelection, initialText)
-        ? toCodeMirrorSelection(externalSelection)
+        ? fromTextSelection(externalSelection)
         : undefined,
       extensions: [
         keymap.of([indentWithTab, formatCompactKeyBinding]),
@@ -823,7 +824,7 @@
       return
     }
 
-    const selection = toCodeMirrorSelection(externalSelection)
+    const selection = fromTextSelection(externalSelection)
     if (codeMirrorView && selection && (!editorState || !editorState.selection.eq(selection))) {
       debug('applyExternalSelection', selection)
 
@@ -832,7 +833,7 @@
     }
   }
 
-  function toCodeMirrorSelection(
+  function fromTextSelection(
     selection: JSONEditorSelection | undefined
   ): EditorSelection | undefined {
     return isTextSelection(selection) ? EditorSelection.fromJSON(selection) : undefined
@@ -985,10 +986,14 @@
   }
 
   function emitOnSelect() {
-    onSelect({
+    onSelect(toTextSelection(editorState.selection))
+  }
+
+  function toTextSelection(selection: EditorSelection): TextSelection {
+    return {
       type: SelectionType.text,
-      ...editorState.selection.toJSON()
-    })
+      ...selection.toJSON()
+    }
   }
 
   function disableTextEditor(text: string, acceptTooLarge: boolean): boolean {

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -726,7 +726,7 @@
       codeMirrorView.dispatch(
         codeMirrorView.state.update({
           selection: selection.main,
-          scrollIntoView: true
+          scrollIntoView: true // FIXME: scrollIntoView also affects scroll of the main page, possibly causing the main page to scroll when jsoneditor has an initial selection
         })
       )
     }

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -719,9 +719,19 @@
 
     codeMirrorView = new EditorView({
       state,
-      parent: target,
-      scrollTo: selection ? EditorView.scrollIntoView(selection.main) : undefined
+      parent: target
     })
+
+    if (selection) {
+      // important to do via dispatch, since that is executed on the next tick.
+      // Otherwise, the editor is not scrolled down enough when the statusbar is rendered on the next tick
+      codeMirrorView.dispatch(
+        codeMirrorView.state.update({
+          selection: selection.main,
+          scrollIntoView: true
+        })
+      )
+    }
 
     return codeMirrorView
   }

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -51,7 +51,7 @@
     keymap,
     lineNumbers,
     rectangularSelection,
-    ViewUpdate
+    type ViewUpdate
   } from '@codemirror/view'
   import { defaultKeymap, indentWithTab } from '@codemirror/commands'
   import type { Diagnostic } from '@codemirror/lint'

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -261,6 +261,8 @@
   })
 
   onDestroy(() => {
+    flush()
+
     if (codeMirrorView) {
       debug('Destroy CodeMirror editor')
       codeMirrorView.destroy()
@@ -280,10 +282,6 @@
   // modalOpen is true when one of the modals is open.
   // This is used to track whether the editor still has focus
   let modalOpen = false
-
-  onDestroy(() => {
-    flush()
-  })
 
   createFocusTracker({
     onMount,
@@ -987,7 +985,7 @@
     TEXT_MODE_ONCHANGE_DELAY
   )
 
-  function flush() {
+  export function flush() {
     onChangeCodeMirrorValueDebounced.flush()
   }
 

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -111,8 +111,8 @@
     ContextMenuItem,
     ConvertType,
     DocumentState,
-    HistoryItem,
     History,
+    HistoryItem,
     InsertType,
     JSONEditorSelection,
     JSONParser,
@@ -128,12 +128,14 @@
     OnExpand,
     OnFocus,
     OnJSONEditorModal,
+    OnRedo,
     OnRenderContextMenuInternal,
     OnRenderMenuInternal,
     OnRenderValue,
     OnSelect,
     OnSortModal,
     OnTransformModal,
+    OnUndo,
     ParseError,
     PastedJson,
     SearchResultDetails,
@@ -198,6 +200,8 @@
   export let onChange: OnChange
   export let onChangeMode: OnChangeMode
   export let onSelect: OnSelect
+  export let onUndo: OnUndo
+  export let onRedo: OnRedo
   export let onRenderValue: OnRenderValue
   export let onRenderMenu: OnRenderMenuInternal
   export let onRenderContextMenu: OnRenderContextMenuInternal
@@ -239,7 +243,15 @@
 
   let documentStateInitialized = false
   let documentState: DocumentState | undefined = createDocumentState({ json })
-  let selection: JSONSelection | undefined
+  let selection: JSONSelection | undefined = isJSONSelection(externalSelection)
+    ? externalSelection
+    : undefined
+
+  onMount(() => {
+    if (selection) {
+      scrollIntoView(getFocusPath(selection))
+    }
+  })
 
   function handleSelect(updatedSelection: JSONSelection | undefined) {
     selection = updatedSelection
@@ -950,6 +962,8 @@
 
     const item = history.undo()
     if (!isTreeHistoryItem(item)) {
+      onUndo(item)
+
       return
     }
 
@@ -993,6 +1007,8 @@
 
     const item = history.redo()
     if (!isTreeHistoryItem(item)) {
+      onRedo(item)
+
       return
     }
 

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -249,7 +249,9 @@
 
   onMount(() => {
     if (selection) {
-      scrollIntoView(getFocusPath(selection))
+      const path = getFocusPath(selection)
+      documentState = expandPath(json, documentState, path, expandNone)
+      setTimeout(() => scrollIntoView(path))
     }
   })
 

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -112,7 +112,7 @@
     ConvertType,
     DocumentState,
     HistoryItem,
-    HistoryRoot,
+    History,
     InsertType,
     JSONEditorSelection,
     JSONParser,
@@ -183,7 +183,7 @@
   export let readOnly: boolean
   export let externalContent: Content
   export let externalSelection: JSONEditorSelection | undefined
-  export let history: HistoryRoot<HistoryItem>
+  export let history: History<HistoryItem>
   export let mainMenuBar: boolean
   export let navigationBar: boolean
   export let escapeControlCharacters: boolean

--- a/src/lib/components/modes/treemode/menu/TreeMenu.svelte
+++ b/src/lib/components/modes/treemode/menu/TreeMenu.svelte
@@ -16,7 +16,7 @@
   import Menu from '../../../controls/Menu.svelte'
   import type {
     HistoryItem,
-    HistoryRoot,
+    History,
     JSONSelection,
     MenuItem,
     OnRenderMenuInternal
@@ -28,7 +28,7 @@
 
   export let readOnly: boolean
   export let showSearch = false
-  export let history: HistoryRoot<HistoryItem>
+  export let history: History<HistoryItem>
 
   export let onExpandAll: () => void
   export let onCollapseAll: () => void

--- a/src/lib/components/modes/treemode/menu/TreeMenu.svelte
+++ b/src/lib/components/modes/treemode/menu/TreeMenu.svelte
@@ -14,16 +14,21 @@
   import { faJSONEditorCollapse, faJSONEditorExpand } from '$lib/img/customFontawesomeIcons.js'
   import { isObjectOrArray } from '$lib/utils/typeUtils.js'
   import Menu from '../../../controls/Menu.svelte'
-  import type { JSONSelection, MenuItem, OnRenderMenuInternal } from '$lib/types'
+  import type {
+    HistoryItem,
+    HistoryRoot,
+    JSONSelection,
+    MenuItem,
+    OnRenderMenuInternal
+  } from '$lib/types'
   import { isKeySelection, isMultiSelection, isValueSelection } from '$lib/logic/selection.js'
-  import type { HistoryState } from '$lib/logic/history.js'
 
   export let json: unknown
   export let selection: JSONSelection | undefined
 
   export let readOnly: boolean
   export let showSearch = false
-  export let historyState: HistoryState
+  export let history: HistoryRoot<HistoryItem>
 
   export let onExpandAll: () => void
   export let onCollapseAll: () => void
@@ -115,7 +120,7 @@
           title: 'Undo (Ctrl+Z)',
           className: 'jse-undo',
           onClick: onUndo,
-          disabled: !historyState.canUndo
+          disabled: !history.canUndo
         },
         {
           type: 'button',
@@ -123,7 +128,7 @@
           title: 'Redo (Ctrl+Shift+Z)',
           className: 'jse-redo',
           onClick: onRedo,
-          disabled: !historyState.canRedo
+          disabled: !history.canRedo
         },
         {
           type: 'space'

--- a/src/lib/logic/history.ts
+++ b/src/lib/logic/history.ts
@@ -16,12 +16,12 @@ export function createHistoryInstance<T>(options: HistoryOptions<T> = {}): Histo
   /**
    * items in history are sorted from newest first to oldest last
    */
-  let items: T[] = []
+  let reverseItems: T[] = []
 
   let index = 0
 
   function canUndo(): boolean {
-    return index < items.length
+    return index < reverseItems.length
   }
 
   function canRedo(): boolean {
@@ -32,7 +32,7 @@ export function createHistoryInstance<T>(options: HistoryOptions<T> = {}): Histo
     return {
       canUndo: canUndo(),
       canRedo: canRedo(),
-      length: items.length,
+      items: () => reverseItems.slice().reverse(),
       add,
       undo,
       redo,
@@ -49,7 +49,7 @@ export function createHistoryInstance<T>(options: HistoryOptions<T> = {}): Histo
   function add(item: T) {
     debug('add', item)
 
-    items = [item].concat(items.slice(index)).slice(0, maxItems)
+    reverseItems = [item].concat(reverseItems.slice(index)).slice(0, maxItems)
 
     index = 0
 
@@ -59,7 +59,7 @@ export function createHistoryInstance<T>(options: HistoryOptions<T> = {}): Histo
   function clear() {
     debug('clear')
 
-    items = []
+    reverseItems = []
     index = 0
 
     handleChange()
@@ -67,7 +67,7 @@ export function createHistoryInstance<T>(options: HistoryOptions<T> = {}): Histo
 
   function undo(): T | undefined {
     if (canUndo()) {
-      const item = items[index]
+      const item = reverseItems[index]
       index += 1
 
       debug('undo', item)
@@ -84,11 +84,11 @@ export function createHistoryInstance<T>(options: HistoryOptions<T> = {}): Histo
     if (canRedo()) {
       index -= 1
 
-      debug('redo', items[index])
+      debug('redo', reverseItems[index])
 
       handleChange()
 
-      return items[index]
+      return reverseItems[index]
     }
 
     return undefined

--- a/src/lib/logic/history.ts
+++ b/src/lib/logic/history.ts
@@ -1,22 +1,16 @@
 import { createDebug } from '../utils/debug.js'
-import type { History, HistoryState } from 'svelte-jsoneditor'
+import type { HistoryInstance, History } from 'svelte-jsoneditor'
 
 const MAX_HISTORY_ITEMS = 1000
 
 const debug = createDebug('jsoneditor:History')
 
-/**
- * @typedef {*} HistoryItem
- * @property {Object} undo
- * @property {Object} redo
- */
-
-export interface HistoryOptions {
+export interface HistoryOptions<T> {
   maxItems?: number
-  onChange?: (props: { canUndo: boolean; canRedo: boolean; length: number }) => void
+  onChange?: (state: History<T>) => void
 }
 
-export function createHistory<T>(options: HistoryOptions = {}): History<T> {
+export function createHistoryInstance<T>(options: HistoryOptions<T> = {}): HistoryInstance<T> {
   const maxItems = options.maxItems || MAX_HISTORY_ITEMS
 
   /**
@@ -34,17 +28,21 @@ export function createHistory<T>(options: HistoryOptions = {}): History<T> {
     return index > 0
   }
 
-  function getState(): HistoryState {
+  function get(): History<T> {
     return {
       canUndo: canUndo(),
       canRedo: canRedo(),
-      length: items.length
+      length: items.length,
+      add,
+      undo,
+      redo,
+      clear
     }
   }
 
   function handleChange() {
     if (options.onChange) {
-      options.onChange(getState())
+      options.onChange(get())
     }
   }
 
@@ -97,10 +95,6 @@ export function createHistory<T>(options: HistoryOptions = {}): History<T> {
   }
 
   return {
-    add,
-    clear,
-    getState,
-    undo,
-    redo
+    get
   }
 }

--- a/src/lib/logic/history.ts
+++ b/src/lib/logic/history.ts
@@ -1,4 +1,5 @@
 import { createDebug } from '../utils/debug.js'
+import type { History, HistoryState } from 'svelte-jsoneditor'
 
 const MAX_HISTORY_ITEMS = 1000
 
@@ -13,20 +14,6 @@ const debug = createDebug('jsoneditor:History')
 export interface HistoryOptions {
   maxItems?: number
   onChange?: (props: { canUndo: boolean; canRedo: boolean; length: number }) => void
-}
-
-export interface HistoryState {
-  canUndo: boolean
-  canRedo: boolean
-  length: number
-}
-
-export interface History<T> {
-  add: (item: T) => void
-  clear: () => void
-  getState: () => HistoryState
-  undo: () => T | undefined
-  redo: () => T | undefined
 }
 
 export function createHistory<T>(options: HistoryOptions = {}): History<T> {

--- a/src/lib/typeguards.ts
+++ b/src/lib/typeguards.ts
@@ -20,7 +20,8 @@ import type {
   WithSearchResults,
   TreeHistoryItem,
   HistoryItem,
-  TextHistoryItem
+  TextHistoryItem,
+  ModeHistoryItem
 } from './types.js'
 import { isObject } from '$lib/utils/typeUtils.js'
 
@@ -149,4 +150,10 @@ export function isTextHistoryItem(
   historyItem: HistoryItem | undefined
 ): historyItem is TextHistoryItem {
   return historyItem ? historyItem.type === 'text' : false
+}
+
+export function isModeHistoryItem(
+  historyItem: HistoryItem | undefined
+): historyItem is ModeHistoryItem {
+  return historyItem ? historyItem.type === 'mode' : false
 }

--- a/src/lib/typeguards.ts
+++ b/src/lib/typeguards.ts
@@ -17,7 +17,10 @@ import type {
   ObjectRecursiveState,
   ValueRecursiveState,
   SearchResults,
-  WithSearchResults
+  WithSearchResults,
+  TreeHistoryItem,
+  HistoryItem,
+  TextHistoryItem
 } from './types.js'
 import { isObject } from '$lib/utils/typeUtils.js'
 
@@ -134,4 +137,16 @@ export function hasSearchResults(state: SearchResults | undefined): state is Wit
     state !== undefined &&
     Array.isArray((state as unknown as Record<string, unknown>).searchResults)
   )
+}
+
+export function isTreeHistoryItem(
+  historyItem: HistoryItem | undefined
+): historyItem is TreeHistoryItem {
+  return historyItem ? historyItem.type === 'tree' : false
+}
+
+export function isTextHistoryItem(
+  historyItem: HistoryItem | undefined
+): historyItem is TextHistoryItem {
+  return historyItem ? historyItem.type === 'text' : false
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -525,27 +525,18 @@ export interface TextHistoryItem {
 
 export type HistoryItem = TreeHistoryItem | TextHistoryItem
 
-export interface HistoryState {
-  canUndo: boolean
-  canRedo: boolean
-  length: number
+export interface HistoryInstance<T> {
+  get: () => History<T>
 }
 
 export interface History<T> {
+  canUndo: boolean
+  canRedo: boolean
+  length: number
   add: (item: T) => void
   clear: () => void
-  getState: () => HistoryState
   undo: () => T | undefined
   redo: () => T | undefined
-}
-
-export interface HistoryRoot<T> extends HistoryState {
-  add: History<T>['add']
-  undo: History<T>['undo']
-  redo: History<T>['redo']
-  canUndo: HistoryState['canUndo']
-  canRedo: HistoryState['canRedo']
-  length: HistoryState['length']
 }
 
 export type ConvertType = 'value' | 'object' | 'array'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -508,6 +508,17 @@ export interface HistoryItem {
   }
 }
 
+export interface TextHistoryItem {
+  undo: {
+    changes: unknown // FIXME: write out this type
+    selection: unknown // FIXME: change to JSONEditorSelection?
+  }
+  redo: {
+    changes: unknown // FIXME: write out this type
+    selection: unknown // FIXME: change to JSONEditorSelection?
+  }
+}
+
 export type ConvertType = 'value' | 'object' | 'array'
 export type InsertType = ConvertType | 'structure'
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -508,14 +508,16 @@ export interface HistoryItem {
   }
 }
 
+export type TextChanges = Array<number | [number, ...string[]]>
+
 export interface TextHistoryItem {
   undo: {
-    changes: unknown // FIXME: write out this type
-    selection: unknown // FIXME: change to JSONEditorSelection?
+    changes: TextChanges
+    selection: TextSelection
   }
   redo: {
-    changes: unknown // FIXME: write out this type
-    selection: unknown // FIXME: change to JSONEditorSelection?
+    changes: TextChanges
+    selection: TextSelection
   }
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -487,7 +487,8 @@ export interface RenderedItem {
   height: number
 }
 
-export interface HistoryItem {
+export interface TreeHistoryItem {
+  type: 'tree'
   undo: {
     patch: JSONPatchDocument | undefined
     json: unknown | undefined
@@ -511,6 +512,7 @@ export interface HistoryItem {
 export type TextChanges = Array<number | [number, ...string[]]>
 
 export interface TextHistoryItem {
+  type: 'text'
   undo: {
     changes: TextChanges
     selection: TextSelection
@@ -519,6 +521,31 @@ export interface TextHistoryItem {
     changes: TextChanges
     selection: TextSelection
   }
+}
+
+export type HistoryItem = TreeHistoryItem | TextHistoryItem
+
+export interface HistoryState {
+  canUndo: boolean
+  canRedo: boolean
+  length: number
+}
+
+export interface History<T> {
+  add: (item: T) => void
+  clear: () => void
+  getState: () => HistoryState
+  undo: () => T | undefined
+  redo: () => T | undefined
+}
+
+export interface HistoryRoot<T> extends HistoryState {
+  add: History<T>['add']
+  undo: History<T>['undo']
+  redo: History<T>['redo']
+  canUndo: HistoryState['canUndo']
+  canRedo: HistoryState['canRedo']
+  length: HistoryState['length']
 }
 
 export type ConvertType = 'value' | 'object' | 'array'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -588,6 +588,7 @@ export interface AbsolutePopupContext {
 
 export interface JSONEditorPropsOptional {
   content?: Content
+  selection?: JSONEditorSelection
   readOnly?: boolean
   indentation?: number | string
   tabSize?: number

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -384,6 +384,8 @@ export type OnChange =
   | undefined
 export type OnJSONSelect = (selection: JSONSelection) => void
 export type OnSelect = (selection: JSONEditorSelection | undefined) => void
+export type OnUndo = (item: HistoryItem | undefined) => void
+export type OnRedo = (item: HistoryItem | undefined) => void
 export type OnPatch = (
   operations: JSONPatchDocument,
   afterPatch?: AfterPatchCallback
@@ -523,7 +525,19 @@ export interface TextHistoryItem {
   }
 }
 
-export type HistoryItem = TreeHistoryItem | TextHistoryItem
+export interface ModeHistoryItem {
+  type: 'mode'
+  undo: {
+    mode: Mode
+    selection: undefined // selection can be restored used the corresponding sibling HistoryItem
+  }
+  redo: {
+    mode: Mode
+    selection: undefined // selection can be restored used the corresponding sibling HistoryItem
+  }
+}
+
+export type HistoryItem = TreeHistoryItem | TextHistoryItem | ModeHistoryItem
 
 export interface HistoryInstance<T> {
   get: () => History<T>
@@ -532,7 +546,7 @@ export interface HistoryInstance<T> {
 export interface History<T> {
   canUndo: boolean
   canRedo: boolean
-  length: number
+  items: () => T[]
   add: (item: T) => void
   clear: () => void
   undo: () => T | undefined


### PR DESCRIPTION
Currently, when switching mode, you lose all your history. This makes it an unsafe action. 

This PR lets the editor maintain history when switching modes:

- Creates a custom history for the codemirror editor (text mode), controlled by `TextMode`
- Moves the history to `JSONEditorRoot`, maintaining a single history for all three modes. 
- Adds switching mode as a new history item.
- Fixes not being able to change property `selection` via method `updateProps`.