### PR TITLE
feat: add createAjvValidatorAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,7 @@ The library exports a set of utility functions. The exact definitions of those f
     - `keyComboFromEvent`
 - Validation:
   - `createAjvValidator`
+  - `createAjvValidatorAsync`
 - Query languages:
   - `jsonQueryLanguage`
   - `jmespathQueryLanguage`

--- a/README.md
+++ b/README.md
@@ -328,13 +328,38 @@ True by default. Only applicable to `'table'` mode. When `true`, nested object p
 validator: function (json: unknown): ValidationError[]
 ```
 
-Validate the JSON document. For example use the built-in JSON Schema validator powered by Ajv:
+Validate the JSON document.
+
+##### Using Ajv for JSON Schema
+
+You can use the built-in JSON Schema validator powered by Ajv:
 
 ```js
 import { createAjvValidator } from 'svelte-jsoneditor'
 
 const validator = createAjvValidator({ schema, schemaDefinitions })
 ```
+
+##### Resolving Remote Schemas
+
+If you want Ajv to load remote schemas through its `loadSchema` function, use the async validator builder like this:
+
+```js
+import { createAjvValidatorAsync } from 'svelte-jsoneditor'
+
+const validator = await createAjvValidatorAsync({
+  schema: {
+    $ref: "/schema.json",
+  },
+  ajvOptions: {
+    loadSchema: function (uri: string) {
+      return fetch(uri).then((response) => response.json());
+    },
+  },
+});
+```
+
+`createAjvValidatorAsync` resolves only after Ajv has loaded and compiled all referenced schemas, or rejects on errors, e.g. if `loadSchema` returns a rejected promise.
 
 #### parser
 

--- a/src/lib/plugins/validator/createAjvValidator.test.ts
+++ b/src/lib/plugins/validator/createAjvValidator.test.ts
@@ -258,8 +258,17 @@ describe.each([
     ])
   })
 
+  if (create === createAjvValidator) {
+    test('should return validator synchronously', () => {
+      const validate = createAjvValidator(options)
+
+      assert(typeof validate === 'function', 'validator is a function')
+      assert(Array.isArray(validate(invalidJson)), 'validator is callable and returns an array')
+    })
+  }
+
   if (create === createAjvValidatorAsync) {
-    test('resolves remote schema using loadSchema', async () => {
+    test('should resolve remote schema using loadSchema', async () => {
       let loadSchemaCalled = false
 
       const loadSchema = async (uri: string) => {
@@ -292,7 +301,7 @@ describe.each([
       assert.ok(loadSchemaCalled)
     })
 
-    test('rejects if loadSchema returns a rejected promise', async () => {
+    test('should reject if loadSchema returns a rejected promise', async () => {
       const loadSchema = async () => {
         throw new Error('Failed to load schema: Schema not found: /schema.json')
       }


### PR DESCRIPTION
This PR adds a new function, `createAjvValidatorAsync` to the Ajv plugin.

It behaves like `createAjvValidator`, but uses `ajv.compileAsync` on the schema which allows for resolution of remote schemas through the `loadSchema(uri)` hook of Ajv's `options`.

Due to the async nature of `compileAsync`, the return format changes, which would be a breaking change. So I opted for a second factory function in order to not break existing consumers.

The PR also adds `errorSeverity` as an option.

As you can see, I have refactored the code a bit s.t. as little code as possible is duplicated. It had a bit of an unfortunate impact on the testing code, where I also tried to not duplicate all the existing tests just be cause there now is a second factory function.

Thanks for your work & please let me know if you want anything changed :)