### PR TITLE
chore(ci): set up automated releases

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -1,0 +1,33 @@
+name: Continuous integration (release)
+on:
+  push:
+    branches:
+      - main
+jobs:
+  automated-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          token: ${{ secrets.NPM_TOKEN }}
+          cache-dependency-path: "package-lock.json"
+      - run: npm run release:lint
+      - run: npm run release:test-ci
+      - run: npm run release:check
+      - run: npm run release:build
+      - run: >
+          npx
+          -p "@semantic-release/commit-analyzer"
+          -p "@semantic-release/release-notes-generator"
+          -p conventional-changelog-conventionalcommits
+          -p semantic-release
+          -- semantic-release
+permissions:
+  # packages: write # This is for pushing it to githubs package repository
+  contents: write
+  issues: write # This is for posting to issues that they are resolved in a release
+  pull-requests: write # This is for posting to PRs that they are part of a release
+  id-token: write # This is for provenance, see https://github.com/semantic-release/npm

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: 22
           cache: npm
           token: ${{ secrets.NPM_TOKEN }}
-          cache-dependency-path: "package-lock.json"
+          cache-dependency-path: 'package-lock.json'
       - run: npm run release:lint
       - run: npm run release:test-ci
       - run: npm run release:check

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,34 +1,34 @@
 {
-	"branches": ["main"],
-	"plugins": [
-		[
-			"@semantic-release/commit-analyzer",
-			{
-				"preset": "conventionalcommits"
-			}
-		],
-		[
-			"@semantic-release/npm",
-			{
-				"pkgRoot": "package",
-				"tarballDir": "tars",
-				"npmPublish": false
-			}
-		],
-		[
-			"@semantic-release/npm",
-			{
-				"pkgRoot": "package-vanilla",
-				"tarballDir": "tars",
-				"npmPublish": false
-			}
-		],
-		[
-			"@semantic-release/github",
-			{
-				"assets": "tars/*.tgz"
-			}
-		],
-		"@semantic-release/release-notes-generator"
-	]
+  "branches": ["main"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/npm",
+      {
+        "pkgRoot": "package",
+        "tarballDir": "tars",
+        "npmPublish": false
+      }
+    ],
+    [
+      "@semantic-release/npm",
+      {
+        "pkgRoot": "package-vanilla",
+        "tarballDir": "tars",
+        "npmPublish": false
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": "tars/*.tgz"
+      }
+    ],
+    "@semantic-release/release-notes-generator"
+  ]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,34 @@
+{
+	"branches": ["main"],
+	"plugins": [
+		[
+			"@semantic-release/commit-analyzer",
+			{
+				"preset": "conventionalcommits"
+			}
+		],
+		[
+			"@semantic-release/npm",
+			{
+				"pkgRoot": "package",
+				"tarballDir": "tars",
+				"npmPublish": false
+			}
+		],
+		[
+			"@semantic-release/npm",
+			{
+				"pkgRoot": "package-vanilla",
+				"tarballDir": "tars",
+				"npmPublish": false
+			}
+		],
+		[
+			"@semantic-release/github",
+			{
+				"assets": "tars/*.tgz"
+			}
+		],
+		"@semantic-release/release-notes-generator"
+	]
+}


### PR DESCRIPTION
This sets up automated releases, triggered by pushing (or merging into) `main`.

Requirements:
- [x] Set up an NPM_TOKEN repository secret to allow it to publish to NPM.
- [ ] Verify that it works, currently it will create releases / tags on github but it will not publish them to NPM.
- [ ] When happy that it works set `npmPublish` to `true` in `.releaserc.json`, or simply remove it from there.

I've always found these kinds of workflows hard to set up without a few iterations, unfortunately these iterations require merging every PR since the flow must only run on `main`.
In this case we might get some tags on github, but by disabling NPM publish users of the package should not notice this.

If you want to be even more careful you could have it just dry run at first, but then you don't test half the flow, since things like posting to an issue might not work if permissions are not set up correctly, same goes for publishing to NPM.