### PR TITLE
feat: use `plaintext-only` to prevent rich-text edits when editing a value

### DIFF
--- a/src/lib/components/controls/EditableDiv.scss
+++ b/src/lib/components/controls/EditableDiv.scss
@@ -25,6 +25,7 @@ div.jse-editable-div {
     white-space: nowrap;
   }
 
+  &[contenteditable='plaintext-only'],
   &[contenteditable='true'] {
     outline: defaults.$edit-outline;
     background: defaults.$background-color;

--- a/src/lib/components/controls/EditableDiv.svelte
+++ b/src/lib/components/controls/EditableDiv.svelte
@@ -2,7 +2,12 @@
 
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte'
-  import { addNewLineSuffix, removeNewLineSuffix, setCursorToEnd } from '$lib/utils/domUtils.js'
+  import {
+    addNewLineSuffix,
+    removeNewLineSuffix,
+    setCursorToEnd,
+    supportsPlaintextOnlyContentEditable
+  } from '$lib/utils/domUtils.js'
   import { keyComboFromEvent } from '$lib/utils/keyBindings.js'
   import { createDebug } from '$lib/utils/debug.js'
   import { noop } from 'lodash-es'
@@ -153,7 +158,7 @@
   aria-label={label}
   tabindex="0"
   class={classnames('jse-editable-div', valueClass, { 'jse-short-text': shortText })}
-  contenteditable="true"
+  contenteditable={supportsPlaintextOnlyContentEditable() ? 'plaintext-only' : 'true'}
   spellcheck="false"
   on:input={handleValueInput}
   on:keydown={handleValueKeyDown}

--- a/src/lib/components/controls/EditableDiv.svelte
+++ b/src/lib/components/controls/EditableDiv.svelte
@@ -6,7 +6,7 @@
     addNewLineSuffix,
     removeNewLineSuffix,
     setCursorToEnd,
-    supportsPlaintextOnlyContentEditable
+    supportsPlaintextOnly
   } from '$lib/utils/domUtils.js'
   import { keyComboFromEvent } from '$lib/utils/keyBindings.js'
   import { createDebug } from '$lib/utils/debug.js'
@@ -158,7 +158,7 @@
   aria-label={label}
   tabindex="0"
   class={classnames('jse-editable-div', valueClass, { 'jse-short-text': shortText })}
-  contenteditable={supportsPlaintextOnlyContentEditable() ? 'plaintext-only' : 'true'}
+  contenteditable={supportsPlaintextOnly() ? 'plaintext-only' : 'true'}
   spellcheck="false"
   on:input={handleValueInput}
   on:keydown={handleValueKeyDown}

--- a/src/lib/utils/domUtils.ts
+++ b/src/lib/utils/domUtils.ts
@@ -162,19 +162,19 @@ export function isContentEditableDiv(element: HTMLElement): boolean {
 }
 
 /**
- * Test whether the current browser supports div.contentEditable='plaintext-only'
+ * Test whether the current browser supports <div contenteditable="plaintext-only"></div>
  * Source: https://stackoverflow.com/a/18316972/1262753
  */
-export function supportsPlaintextOnlyContentEditable() {
-  if (_supportsPlaintextOnlyContentEditable === undefined) {
+export function supportsPlaintextOnly() {
+  if (_supportsPlaintextOnly === undefined) {
     const div = document.createElement('div')
     div.setAttribute('contenteditable', 'plaintext-only')
-    _supportsPlaintextOnlyContentEditable = div.isContentEditable
+    _supportsPlaintextOnly = div.isContentEditable
   }
 
-  return _supportsPlaintextOnlyContentEditable
+  return _supportsPlaintextOnly
 }
-let _supportsPlaintextOnlyContentEditable: boolean | undefined = undefined
+let _supportsPlaintextOnly: boolean | undefined = undefined
 
 // test whether a DOM element is an "input" with type "text"
 export function isTextInput(element: HTMLInputElement): boolean {

--- a/src/lib/utils/domUtils.ts
+++ b/src/lib/utils/domUtils.ts
@@ -158,10 +158,7 @@ export function isChildOfAttribute(element: Element, name: string, value: string
 
 // test whether a DOM element is a content editable div
 export function isContentEditableDiv(element: HTMLElement): boolean {
-  return (
-    element.nodeName === 'DIV' &&
-    (element.contentEditable === 'plaintext-only' || element.contentEditable === 'true')
-  )
+  return element.nodeName === 'DIV' && element.isContentEditable
 }
 
 /**

--- a/src/lib/utils/domUtils.ts
+++ b/src/lib/utils/domUtils.ts
@@ -158,8 +158,26 @@ export function isChildOfAttribute(element: Element, name: string, value: string
 
 // test whether a DOM element is a content editable div
 export function isContentEditableDiv(element: HTMLElement): boolean {
-  return element.nodeName === 'DIV' && element.contentEditable === 'true'
+  return (
+    element.nodeName === 'DIV' &&
+    (element.contentEditable === 'plaintext-only' || element.contentEditable === 'true')
+  )
 }
+
+/**
+ * Test whether the current browser supports div.contentEditable='plaintext-only'
+ * Source: https://stackoverflow.com/a/18316972/1262753
+ */
+export function supportsPlaintextOnlyContentEditable() {
+  if (_supportsPlaintextOnlyContentEditable === undefined) {
+    const div = document.createElement('div')
+    div.setAttribute('contenteditable', 'plaintext-only')
+    _supportsPlaintextOnlyContentEditable = div.isContentEditable
+  }
+
+  return _supportsPlaintextOnlyContentEditable
+}
+let _supportsPlaintextOnlyContentEditable: boolean | undefined = undefined
 
 // test whether a DOM element is an "input" with type "text"
 export function isTextInput(element: HTMLInputElement): boolean {


### PR DESCRIPTION
Note that rich-edits are not a big deal, since they mostly occur when pasting rich content, but the editor only pastes plain text contents. Still, explictely making the EditableDiv plain text can prevent odd cases.