### PR TITLE
Add expand/collapse functionality support in TextMode

### DIFF
--- a/src/lib/components/modes/JSONEditorRoot.svelte
+++ b/src/lib/components/modes/JSONEditorRoot.svelte
@@ -227,6 +227,8 @@
   export function expand(path: JSONPath, callback?: OnExpand): void {
     if (refTreeMode) {
       return refTreeMode.expand(path, callback)
+    } else if (refTextMode) {
+      return refTextMode.expand(path, callback)
     } else {
       throw new Error(`Method expand is not available in mode "${mode}"`)
     }
@@ -235,6 +237,8 @@
   export function collapse(path: JSONPath, recursive: boolean): void {
     if (refTreeMode) {
       return refTreeMode.collapse(path, recursive)
+    } else if (refTextMode) {
+      return refTextMode.collapse(path, recursive)
     } else {
       throw new Error(`Method collapse is not available in mode "${mode}"`)
     }

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -28,6 +28,7 @@
   } from '$lib/utils/domUtils.js'
   import { formatSize } from '$lib/utils/fileUtils.js'
   import { findTextLocation, getText, needsFormatting } from '$lib/utils/jsonUtils.js'
+  import { expandSelf } from '$lib/logic/documentState.js'
   import { createFocusTracker } from '../../controls/createFocusTracker.js'
   import Message from '../../controls/Message.svelte'
   import ValidationErrorsOverview from '../../controls/ValidationErrorsOverview.svelte'
@@ -64,7 +65,11 @@
     foldKeymap,
     indentOnInput,
     indentUnit,
-    syntaxHighlighting
+    syntaxHighlighting,
+    foldCode,
+    unfoldCode,
+    foldAll,
+    unfoldAll
   } from '@codemirror/language'
   import {
     closeSearchPanel,
@@ -96,6 +101,7 @@
     OnChange,
     OnChangeMode,
     OnError,
+    OnExpand,
     OnFocus,
     OnRedo,
     OnRenderMenuInternal,
@@ -277,6 +283,67 @@
     if (codeMirrorView) {
       debug('focus')
       codeMirrorView.focus()
+    }
+  }
+
+  export function collapse(path: JSONPath, recursive: boolean) {
+    if (!codeMirrorView) {
+      debug('collapse: CodeMirror view not available')
+    }
+
+    debug('collapse', path, recursive)
+
+    try {
+      if (path && path.length > 0) {
+        // Find the text location of the given JSON path
+        const { from } = findTextLocation(normalization.escapeValue(text), path)
+        
+        if (from !== undefined) {
+          // Set selection to the position we want to fold
+          codeMirrorView.dispatch({
+            selection: { anchor: from, head: from }
+          })
+          // Use CodeMirror's foldCode command for specific path
+          foldCode(codeMirrorView)
+        }
+      } else {
+        foldAll(codeMirrorView)
+      }
+    } catch (err) {
+      debug('collapse error:', err)
+      onError(err as Error)
+    }
+  }
+
+  export function expand(path: JSONPath, callback: OnExpand = expandSelf) {
+    if (!codeMirrorView) {
+      debug('expand: CodeMirror view not available')
+      return
+    }
+
+    debug('expand', path, callback)
+
+    try {
+      if (path && path.length > 0) {
+        // Find the text location of the given JSON path
+        const { from } = findTextLocation(normalization.escapeValue(text), path)
+        
+        if (from !== undefined) {
+          // Set selection to the position we want to unfold
+          codeMirrorView.dispatch({
+            selection: { anchor: from, head: from }
+          })
+          // Use CodeMirror's unfoldCode command for specific path
+          unfoldCode(codeMirrorView)
+        }
+      } else {
+        // When path is empty (expand all)
+        unfoldAll(codeMirrorView)
+      }
+      callback?.(path)
+    } catch (err) {
+      debug('expand error:', err)
+      onError(err as Error)
     }
   }
 

--- a/src/routes/examples/use_methods/+page.svelte
+++ b/src/routes/examples/use_methods/+page.svelte
@@ -11,7 +11,7 @@
       color: '#82b92c',
       null: null,
       number: 123,
-      object: { a: 'b', c: 'd' },
+      object: { a: 'b', c: 'd', nested: { x: 'y', z: 'w' } },
       string: 'Hello World'
     }
   })
@@ -22,6 +22,53 @@
 
   function collapseAll() {
     refJsonEditor.collapse([], true)
+  }
+
+  // Expand specified key function
+  function expandSpecificKey(keyPath) {
+    refJsonEditor.expand(keyPath)
+  }
+
+  // Collapse specified key function  
+  function collapseSpecificKey(keyPath) {
+    refJsonEditor.collapse(keyPath)
+  }
+
+  // Test function - expand object 
+  function expandObject() {
+    expandSpecificKey(['object'])
+  }
+
+  // Test function - collapse object
+  function collapseObject() {
+    collapseSpecificKey(['object'])
+  }
+
+  // Test function - expand array
+  function expandArray() {
+    expandSpecificKey(['array'])
+  }
+
+  // Test function - collapse array
+  function collapseArray() {
+    collapseSpecificKey(['array'])
+  }
+
+  // Test function - expand object.nested (if exists)
+  function expandObjectNested() {
+    // First expand object, then expand its nested property (if exists)
+    refJsonEditor.expand(['object'])
+    // Give a small delay to ensure object is expanded
+    setTimeout(() => {
+      if (content.json.object && content.json.object.nested) {
+        refJsonEditor.expand(['object', 'nested'])
+      }
+    }, 100)
+  }
+
+  // Test function - collapse object.nested
+  function collapseObjectNested() {
+    collapseSpecificKey(['object', 'nested'])
   }
 </script>
 
@@ -35,6 +82,22 @@
 <p>
   <button type="button" onclick={expandAll}>Expand All</button>
   <button type="button" onclick={collapseAll}>Collapse All</button>
+</p>
+
+<p>
+  <strong>Test expand/collapse specific keys:</strong>
+</p>
+
+<p>
+  <button type="button" onclick={expandObject}>Expand object</button>
+  <button type="button" onclick={collapseObject}>Collapse object</button>
+  <button type="button" onclick={expandArray}>Expand array</button>
+  <button type="button" onclick={collapseArray}>Collapse array</button>
+</p>
+
+<p>
+  <button type="button" onclick={expandObjectNested}>Expand object.nested</button>
+  <button type="button" onclick={collapseObjectNested}>Collapse object.nested</button>
 </p>
 
 <div class="editor">


### PR DESCRIPTION
## Summary
This PR implements expand and collapse functionality for TextMode in svelte-jsoneditor, bringing feature parity with TreeMode. Previously, expand/collapse operations were only available in TreeMode, but now users can programmatically fold/unfold JSON structures in TextMode as well.

## Testing
Added comprehensive test buttons in the examples page (use_methods/+page.svelte):
Expand/Collapse All buttons
Individual key testing (object, array, nested object)
<img width="723" height="675" alt="Clipboard_Screenshot_1752828795" src="https://github.com/user-attachments/assets/30e821b7-29d3-4700-87f4-5ce7bf4b3090" />
