### PR TITLE
feat: add buttons "Expand All" and "Collapse All" to the menu in text mode

### DIFF
--- a/src/lib/components/__snapshots__/JSONEditor.test.ts.snap
+++ b/src/lib/components/__snapshots__/JSONEditor.test.ts.snap
@@ -676,6 +676,75 @@ exports[`JSONEditor > render text mode 1`] = `
         
         <!---->
         <button
+          class="jse-button jse-expand-all svelte-pf7s2l"
+          title="Expand all"
+          type="button"
+        >
+          <svg
+            aria-label=""
+            class="fa-icon  svelte-1mc5hvj"
+            height="16"
+            role="presentation"
+            style=""
+            version="1.1"
+            viewBox="0 0 512 512"
+            width="16"
+          >
+            <!---->
+            <!---->
+            <path
+              d="M 0,448 V 512 h 512 v -64 z M 0,0 V 64 H 512 V 0 Z M 256,96 128,224 h 256 z M 256,416 384,288 H 128 Z"
+            />
+            <!---->
+            <!---->
+            <!---->
+            
+            <!---->
+          </svg>
+          <!---->
+           
+          <!---->
+        </button>
+        
+        <!---->
+        <button
+          class="jse-button jse-collapse-all svelte-pf7s2l"
+          title="Collapse all"
+          type="button"
+        >
+          <svg
+            aria-label=""
+            class="fa-icon  svelte-1mc5hvj"
+            height="16"
+            role="presentation"
+            style=""
+            version="1.1"
+            viewBox="0 0 512 512"
+            width="16"
+          >
+            <!---->
+            <!---->
+            <path
+              d="m 0,224 v 64 h 512 v -64 z M 256,192 384,64 H 128 Z M 256,320 128,448 h 256 z"
+            />
+            <!---->
+            <!---->
+            <!---->
+            
+            <!---->
+          </svg>
+          <!---->
+           
+          <!---->
+        </button>
+        
+        <!---->
+        <div
+          class="jse-separator svelte-pf7s2l"
+        />
+        
+        <!---->
+        <button
           class="jse-button jse-format svelte-pf7s2l"
           title="Format JSON: add proper indentation and new lines (Ctrl+I)"
           type="button"

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -492,6 +492,14 @@
     }
   }
 
+  function handleExpandAll() {
+    expand([], () => true)
+  }
+
+  function handleCollapseAll() {
+    collapse([], true)
+  }
+
   // modalOpen is true when one of the modals is open.
   // This is used to track whether the editor still has focus
   let modalOpen = false
@@ -1318,6 +1326,8 @@
 
     <TextMenu
       {readOnly}
+      onExpandAll={handleExpandAll}
+      onCollapseAll={handleCollapseAll}
       onFormat={handleFormat}
       onCompact={handleCompact}
       onSort={handleSort}
@@ -1325,6 +1335,8 @@
       onToggleSearch={handleToggleSearch}
       onUndo={handleUndo}
       onRedo={handleRedo}
+      canExpandAll={!isNewDocument}
+      canCollapseAll={!isNewDocument}
       canFormat={!isNewDocument}
       canCompact={!isNewDocument}
       canSort={!isNewDocument}

--- a/src/lib/components/modes/textmode/menu/TextMenu.svelte
+++ b/src/lib/components/modes/textmode/menu/TextMenu.svelte
@@ -8,11 +8,18 @@
     faSortAmountDownAlt,
     faUndo
   } from '@fortawesome/free-solid-svg-icons'
-  import { faJSONEditorCompact, faJSONEditorFormat } from '$lib/img/customFontawesomeIcons.js'
+  import {
+    faJSONEditorCollapse,
+    faJSONEditorCompact,
+    faJSONEditorExpand,
+    faJSONEditorFormat
+  } from '$lib/img/customFontawesomeIcons.js'
   import Menu from '../../../controls/Menu.svelte'
   import type { MenuItem, OnRenderMenuInternal } from '$lib/types'
 
   export let readOnly = false
+  export let onExpandAll: () => void
+  export let onCollapseAll: () => void
   export let onFormat: () => boolean
   export let onCompact: () => boolean
   export let onSort: () => void
@@ -20,6 +27,8 @@
   export let onToggleSearch: () => void
   export let onUndo: () => void
   export let onRedo: () => void
+  export let canExpandAll: boolean
+  export let canCollapseAll: boolean
   export let canUndo: boolean
   export let canRedo: boolean
   export let canFormat: boolean
@@ -27,6 +36,26 @@
   export let canSort: boolean
   export let canTransform: boolean
   export let onRenderMenu: OnRenderMenuInternal
+
+  let expandMenuItem: MenuItem
+  $: expandMenuItem = {
+    type: 'button',
+    icon: faJSONEditorExpand,
+    title: 'Expand all',
+    className: 'jse-expand-all',
+    onClick: onExpandAll,
+    disabled: !canExpandAll
+  }
+
+  let collapseMenuItem: MenuItem
+  $: collapseMenuItem = {
+    type: 'button',
+    icon: faJSONEditorCollapse,
+    title: 'Collapse all',
+    className: 'jse-collapse-all',
+    onClick: onCollapseAll,
+    disabled: !canCollapseAll
+  }
 
   const searchItem: MenuItem = {
     type: 'button',
@@ -39,6 +68,11 @@
   let defaultItems: MenuItem[]
   $: defaultItems = !readOnly
     ? [
+        expandMenuItem,
+        collapseMenuItem,
+        {
+          type: 'separator'
+        },
         {
           type: 'button',
           icon: faJSONEditorFormat,
@@ -99,6 +133,11 @@
         }
       ]
     : [
+        expandMenuItem,
+        collapseMenuItem,
+        {
+          type: 'separator'
+        },
         searchItem,
         {
           type: 'space'


### PR DESCRIPTION
For reference, see the ideas in https://github.com/josdejong/svelte-jsoneditor/pull/558

<img width="464" height="206" alt="image" src="https://github.com/user-attachments/assets/c50b3369-18ee-4783-b261-35cd6984a916" />
