### PR TITLE
feat: make max document size in text mode optionally configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,14 @@ pathParser: JSONPathParser
 
 An optional object with a parse and stringify method to parse and stringify a `JSONPath`, which is an array with property names. The `pathParser` is used in the path editor in the navigation bar, which is opened by clicking the edit button on the right side of the navigation bar. The `pathParser.parse` function is allowed to throw an Error when the input is invalid. By default, a JSON Path notation is used, which looks like `$.data[2].nested.property`. Alternatively, it is possible to use for example a JSON Pointer notation like `/data/2/nested/property` or something custom-made. Related helper functions: `parseJSONPath` and `stringifyJSONPath`, `parseJSONPointer` and `compileJSONPointer`.
 
+#### maxDocumentSizeTextMode
+
+```ts
+maxDocumentSizeTextMode: number
+```
+
+In `text` mode, JSON documents with a total length greater than `maxDocumentSizeTextMode` will not be shown. Instead, a warning will be displayed indicating that the browser may crash if it attempts to load the document. The user can then choose to override the warning and open the document anyway, open the document in the lighter `tree` mode instead, or cancel. The default value is `10 * 1024 * 1024` bytes (10MB).
+
 #### onError
 
 ```ts

--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -67,6 +67,7 @@
   const askToFormatDefault = true
   const escapeControlCharactersDefault = false
   const escapeUnicodeCharactersDefault = false
+  const maxDocumentSizeTextModeDefault = 10 * 1024 * 1024 // 10MB
   const flattenColumnsDefault = true
   const parserDefault = JSON
   const validatorDefault = undefined
@@ -105,6 +106,7 @@
   export let askToFormat: boolean = askToFormatDefault
   export let escapeControlCharacters: boolean = escapeControlCharactersDefault
   export let escapeUnicodeCharacters: boolean = escapeUnicodeCharactersDefault
+  export let maxDocumentSizeTextMode: number = maxDocumentSizeTextModeDefault
   export let flattenColumns: boolean = flattenColumnsDefault
   export let parser: JSONParser = parserDefault
   export let validator: Validator | undefined = validatorDefault
@@ -329,6 +331,9 @@
         case 'escapeUnicodeCharacters':
           escapeUnicodeCharacters = props[name] ?? escapeUnicodeCharactersDefault
           break
+        case 'maxDocumentSizeTextMode':
+          maxDocumentSizeTextMode = props[name] ?? maxDocumentSizeTextModeDefault
+          break
         case 'flattenColumns':
           flattenColumns = props[name] ?? flattenColumnsDefault
           break
@@ -518,6 +523,7 @@
       askToFormat,
       escapeControlCharacters,
       escapeUnicodeCharacters,
+      maxDocumentSizeTextMode,
       flattenColumns,
       parser,
       validator: undefined, // TODO: support partial JSON validation?
@@ -558,6 +564,7 @@
         {askToFormat}
         {mainMenuBar}
         {navigationBar}
+        {maxDocumentSizeTextMode}
         {escapeControlCharacters}
         {escapeUnicodeCharacters}
         {flattenColumns}

--- a/src/lib/components/modals/JSONEditorModal.svelte
+++ b/src/lib/components/modals/JSONEditorModal.svelte
@@ -50,6 +50,7 @@
   export let askToFormat: boolean
   export let escapeControlCharacters: boolean
   export let escapeUnicodeCharacters: boolean
+  export let maxDocumentSizeTextMode: number
   export let flattenColumns: boolean
   export let parser: JSONParser
   export let validator: Validator | undefined
@@ -257,6 +258,7 @@
             {navigationBar}
             {escapeControlCharacters}
             {escapeUnicodeCharacters}
+            {maxDocumentSizeTextMode}
             {flattenColumns}
             {parser}
             {parseMemoizeOne}

--- a/src/lib/components/modes/JSONEditorRoot.svelte
+++ b/src/lib/components/modes/JSONEditorRoot.svelte
@@ -55,6 +55,7 @@
   export let askToFormat: boolean
   export let escapeControlCharacters: boolean
   export let escapeUnicodeCharacters: boolean
+  export let maxDocumentSizeTextMode: number
   export let flattenColumns: boolean
   export let parser: JSONParser
   export let parseMemoizeOne: JSONParser['parse']
@@ -348,6 +349,7 @@
     {statusBar}
     {askToFormat}
     {escapeUnicodeCharacters}
+    maxDocumentSize={maxDocumentSizeTextMode}
     {parser}
     {validator}
     {validationParser}

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -267,7 +267,7 @@
     try {
       codeMirrorView = createCodeMirrorView({
         target: codeMirrorRef,
-        initialText: !disableTextEditor(text, acceptTooLarge)
+        initialText: !disableTextEditor(text, maxDocumentSize, acceptTooLarge)
           ? normalization.escapeValue(text)
           : '',
         readOnly,
@@ -1031,7 +1031,7 @@
     content = newContent
     text = newText
 
-    if (!disableTextEditor(text, acceptTooLarge)) {
+    if (!disableTextEditor(text, maxDocumentSize, acceptTooLarge)) {
       // keep state
       // to reset state: codeMirrorView.setState(EditorState.create({doc: text, extensions: ...}))
       codeMirrorView.dispatch({
@@ -1233,7 +1233,7 @@
     }
   }
 
-  function disableTextEditor(text: string, acceptTooLarge: boolean): boolean {
+  function disableTextEditor(text: string, maxDocumentSize: number, acceptTooLarge: boolean): boolean {
     const tooLarge = text ? text.length > maxDocumentSize : false
     return tooLarge && !acceptTooLarge
   }
@@ -1243,7 +1243,7 @@
   let jsonParseError: ParseError | undefined
 
   function linterCallback(): Diagnostic[] {
-    if (disableTextEditor(text, acceptTooLarge)) {
+    if (disableTextEditor(text, maxDocumentSize, acceptTooLarge)) {
       return []
     }
 
@@ -1366,7 +1366,7 @@
     </div>
   {/if}
   {#if !isSSR}
-    {@const editorDisabled = disableTextEditor(text, acceptTooLarge)}
+    {@const editorDisabled = disableTextEditor(text, maxDocumentSize, acceptTooLarge)}
 
     <div class="jse-contents" class:jse-hidden={editorDisabled} bind:this={codeMirrorRef}></div>
 

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -19,7 +19,6 @@
     JSON_STATUS_REPAIRABLE,
     JSON_STATUS_VALID,
     MAX_CHARACTERS_TEXT_PREVIEW,
-    MAX_DOCUMENT_SIZE_TEXT_MODE,
     TEXT_MODE_ONCHANGE_DELAY
   } from '$lib/constants.js'
   import {
@@ -145,6 +144,7 @@
   export let indentation: number | string
   export let tabSize: number
   export let escapeUnicodeCharacters: boolean
+  export let maxDocumentSize: number
   export let parser: JSONParser
   export let validator: Validator | undefined
   export let validationParser: JSONParser
@@ -1234,7 +1234,7 @@
   }
 
   function disableTextEditor(text: string, acceptTooLarge: boolean): boolean {
-    const tooLarge = text ? text.length > MAX_DOCUMENT_SIZE_TEXT_MODE : false
+    const tooLarge = text ? text.length > maxDocumentSize : false
     return tooLarge && !acceptTooLarge
   }
 
@@ -1374,7 +1374,7 @@
       <Message
         icon={faExclamationTriangle}
         type="error"
-        message={`The JSON document is larger than ${formatSize(MAX_DOCUMENT_SIZE_TEXT_MODE)}, ` +
+        message={`The JSON document is larger than ${formatSize(maxDocumentSize)}, ` +
           `and may crash your browser when loading it in text mode. Actual size: ${formatSize(text.length)}.`}
         actions={[
           {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,7 +18,6 @@ export const DEFAULT_VISIBLE_SECTIONS: Section[] = [{ start: 0, end: ARRAY_SECTI
 export const MAX_VALIDATABLE_SIZE = 100 * 1024 * 1024 // 1 MB
 export const MAX_AUTO_REPAIRABLE_SIZE = 1024 * 1024 // 1 MB
 export const MAX_MULTILINE_PASTE_SIZE = 1024 * 1024 // 1 MB
-export const MAX_DOCUMENT_SIZE_TEXT_MODE = 10 * 1024 * 1024 // 10 MB
 export const MAX_DOCUMENT_SIZE_EXPAND_ALL = 10 * 1024 // 10 KB
 
 export const INSERT_EXPLANATION =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -611,6 +611,7 @@ export interface JSONEditorPropsOptional {
   validator?: Validator | undefined
   validationParser?: JSONParser
   pathParser?: JSONPathParser
+  maxDocumentSizeTextMode?: number
 
   queryLanguages?: QueryLanguage[]
   queryLanguageId?: string
@@ -643,6 +644,7 @@ export interface JSONEditorModalProps {
   askToFormat: boolean
   escapeControlCharacters: boolean
   escapeUnicodeCharacters: boolean
+  maxDocumentSizeTextMode: number
   flattenColumns: boolean
   parser: JSONParser
   validator: Validator | undefined

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -50,6 +50,9 @@
     <li>
       <a href="examples/switch_themes">Switch themes (dark theme) and font size</a>
     </li>
+    <li>
+      <a href="examples/read_only">Read only</a>
+    </li>
   </ul>
 
   <h2>Development</h2>

--- a/src/routes/examples/read_only/+page.svelte
+++ b/src/routes/examples/read_only/+page.svelte
@@ -1,0 +1,41 @@
+<script>
+  import { JSONEditor } from 'svelte-jsoneditor'
+
+  const maxDocumentSizeTextMode = 10 * 1024 * 1024
+
+  let content = $state({
+    text:
+      '{\n' +
+      '  "array": [1, 2, 3],\n' +
+      '  "boolean": true,\n' +
+      '  "color": "#82b92c",\n' +
+      '  "null": null,\n' +
+      '  "number": 123,\n' +
+      '  "object": { "a": "b", "c": "d" },\n' +
+      '  "string": "Hello World"\n' +
+      '}'
+  })
+</script>
+
+<svelte:head>
+  <title>Read only | svelte-jsoneditor</title>
+</svelte:head>
+
+<h1>Read only</h1>
+
+<p>Use JSONEditor in read-only mode, content in this example is supplied by a separate textarea:</p>
+
+<div>
+  <textarea bind:value={content.text} style="width: 700px; height: 200px"></textarea>
+</div>
+
+<div class="editor">
+  <JSONEditor {content} readOnly="true" mode="text" {maxDocumentSizeTextMode} />
+</div>
+
+<style>
+  .editor {
+    width: 700px;
+    height: 400px;
+  }
+</style>

--- a/src/routes/examples/read_only/+page.svelte
+++ b/src/routes/examples/read_only/+page.svelte
@@ -3,8 +3,7 @@
 
   const maxDocumentSizeTextMode = 10 * 1024 * 1024
 
-  let content = $state({
-    text:
+  let text = $state(
       '{\n' +
       '  "array": [1, 2, 3],\n' +
       '  "boolean": true,\n' +
@@ -14,7 +13,7 @@
       '  "object": { "a": "b", "c": "d" },\n' +
       '  "string": "Hello World"\n' +
       '}'
-  })
+  )
 </script>
 
 <svelte:head>
@@ -26,11 +25,11 @@
 <p>Use JSONEditor in read-only mode, content in this example is supplied by a separate textarea:</p>
 
 <div>
-  <textarea bind:value={content.text} style="width: 700px; height: 200px"></textarea>
+  <textarea bind:value={text} style="width: 700px; height: 200px"></textarea>
 </div>
 
 <div class="editor">
-  <JSONEditor {content} readOnly="true" mode="text" {maxDocumentSizeTextMode} />
+  <JSONEditor content={{ text }} readOnly="true" mode="text" {maxDocumentSizeTextMode} />
 </div>
 
 <style>


### PR DESCRIPTION
I want to use this editor in a context where it is preferable to try to display large JSON documents in text mode, even if this causes a performance impact on the user.

Basically, I want to suppress this warning:
<img width="697" height="97" alt="image" src="https://github.com/user-attachments/assets/ef6ad004-ac48-4c79-8609-dc6143b8274d" />

While I could just create a property that suppresses this warning, I think the smarter way to do this is to expose the max size itself as a property, and allow that value to be set to a stupidly large number if necessary.

This is a very simple PR which removes the `MAX_DOCUMENT_SIZE_TEXT_MODE` constant, and replaces it with an optional property called `maxDocumentSizeTextMode`, which can be used to override the max size. The property is optional and defaults to the same as the old constant, 10MB.

I also added a "Read Only" svelte example which I found useful for testing this functionality.

Let me know if you think this needs any changes, I am happy to take suggestions on this.