### PR TITLE
fix: add the missing `jse` prefix to three css variables

### DIFF
--- a/src/lib/themes/defaults.scss
+++ b/src/lib/themes/defaults.scss
@@ -71,7 +71,11 @@ $panel-border: var(--jse-panel-border, $main-border);
 
 $panel-button-color: var(--jse-panel-button-color, inherit);
 $panel-button-background: var(--jse-panel-button-background, transparent);
-$panel-button-color-highlight: var(--panel-button-color-highlight, $text-color);
+// the variable without `jse` prefix is deprecated, it is kept for backward compatibility
+$panel-button-color-highlight: var(
+  --jse-panel-button-color-highlight,
+  var(--panel-button-color-highlight, $text-color)
+);
 $panel-button-background-highlight: var(--jse-panel-button-background-highlight, #e0e0e0);
 
 /* navigation-bar */
@@ -98,7 +102,8 @@ $context-menu-pointer-color: var(--jse-context-menu-pointer-color, $context-menu
 $context-menu-pointer-size: var(--jse-context-menu-pointer-size, calc(1em + 4px));
 $context-menu-tip-background: var(--jse-context-menu-tip-background, rgba(255, 255, 255, 0.2));
 
-$context-menu-tip-color: var(--context-menu-tip-color, inherit);
+// the variable without `jse` prefix is deprecated, it is kept for backward compatibility
+$context-menu-tip-color: var(--jse-context-menu-tip-color, var(--context-menu-tip-color, inherit));
 
 /* contents: json key and values */
 $key-color: var(--jse-key-color, #1a1a1a);
@@ -178,7 +183,11 @@ $message-error-background: var(--jse-message-error-background, $error-color);
 $message-error-color: var(--jse-message-error-color, $white);
 $message-warning-background: var(--jse-message-warning-background, #ffde5c);
 $message-warning-color: var(--jse-message-warning-color, $black);
-$message-success-background: var(--message-success-background, #9ac45d);
+// the variable without `jse` prefix is deprecated, it is kept for backward compatibility
+$message-success-background: var(
+  --jse-message-success-background,
+  var(--message-success-background, #9ac45d)
+);
 $message-success-color: var(--jse-message-success-color, $white);
 $message-info-background: var(--jse-message-info-background, #4f91ff);
 $message-info-color: var(--jse-message-info-color, $white);


### PR DESCRIPTION
Three theme variables in `src/lib/themes/defaults.scss` are read without the `jse` prefix that every other variable uses:

| line | variable | read as |
| --- | --- | --- |
| 74 | `$panel-button-color-highlight` | `--panel-button-color-highlight` |
| 101 | `$context-menu-tip-color` | `--context-menu-tip-color` |
| 181 | `$message-success-background` | `--message-success-background` |

`defaults.scss` is what the README points users to for the list of available variables, so `--jse-panel-button-color-highlight`, `--jse-context-menu-tip-color`, and `--jse-message-success-background` look like they should work, but they are silently ignored.

The bundled themes make the same assumption:

- [`src/lib/themes/jse-theme-dark.css:31`](https://github.com/josdejong/svelte-jsoneditor/blob/develop/src/lib/themes/jse-theme-dark.css#L31) sets `--jse-panel-button-color-highlight`
- [`src/routes/themes/jse-theme-big.css:21`](https://github.com/josdejong/svelte-jsoneditor/blob/develop/src/routes/themes/jse-theme-big.css#L21) sets `--jse-message-success-background`

Neither currently has any effect: in the dark theme, highlighted panel buttons (search box, navigation bar, text mode) fall back to `--jse-text-color` instead of the intended `#e5e5e5`.

## The change

Each of the three now reads the prefixed name first and falls back to the unprefixed one, so any existing override using the old name keeps working:

```scss
$panel-button-color-highlight: var(
  --jse-panel-button-color-highlight,
  var(--panel-button-color-highlight, $text-color)
);
```

Happy to drop the deprecated fallbacks and make it a plain rename if you would rather save that for a major release.