### PR TITLE
fix: apply `--jse-search-match-active-outline` to the active search match

### DIFF
--- a/src/lib/themes/defaults.scss
+++ b/src/lib/themes/defaults.scss
@@ -134,7 +134,11 @@ $collapsed-items-link-color-highlight: var(--jse-collapsed-items-link-color-high
 $search-match-color: var(--jse-search-match-color, #ffe665);
 $search-match-outline: var(--jse-search-match-outline, none);
 $search-match-active-color: var(--jse-search-match-active-color, $search-match-color);
-$search-match-active-outline: var(--jse-search-match-outline, (2px solid #e0be00));
+// falling back to the outline of the non-active search matches for backward compatibility
+$search-match-active-outline: var(
+  --jse-search-match-active-outline,
+  var(--jse-search-match-outline, (2px solid #e0be00))
+);
 
 /* contents: inline tags inside the JSON document */
 $tag-background: var(--jse-tag-background, rgba(0, 0, 0, 0.2));


### PR DESCRIPTION
[`src/lib/themes/defaults.scss:137`](https://github.com/josdejong/svelte-jsoneditor/blob/develop/src/lib/themes/defaults.scss#L137) reads the wrong variable:

```scss
$search-match-outline: var(--jse-search-match-outline, none);
$search-match-active-color: var(--jse-search-match-active-color, $search-match-color);
$search-match-active-outline: var(--jse-search-match-outline, (2px solid #e0be00)); // <--
```

`$search-match-active-outline` falls back to the outline of the *non-active* matches, so `--jse-search-match-active-outline` is ignored and the active match cannot be outlined separately. The neighbouring `$search-match-active-color` shows the intended pattern.

The bundled dark theme already sets it, and it currently has no effect ([`jse-theme-dark.css:73-76`](https://github.com/josdejong/svelte-jsoneditor/blob/develop/src/lib/themes/jse-theme-dark.css#L73-L76)):

```css
--jse-search-match-color: #724c27;
--jse-search-match-outline: 1px solid #966535;
--jse-search-match-active-color: #9f6c39;
--jse-search-match-active-outline: 1px solid #bb7f43;  /* ignored */
```

So in the dark theme the active match is currently distinguished only by its background colour, and gets `#966535` where `#bb7f43` was intended. It affects all three modes — `SearchResultHighlighter.scss`, `InlineValue.scss`, and `TextMode.scss` all use `$search-match-active-outline`.

## The change

The active variable now takes precedence and falls back to the non-active outline, so themes that only set `--jse-search-match-outline` keep rendering exactly as they do today:

```scss
$search-match-active-outline: var(
  --jse-search-match-active-outline,
  var(--jse-search-match-outline, (2px solid #e0be00))
);
```

Separate from #578, which fixes three variables read without the `jse` prefix — the two do not overlap.
