### PR TITLE
feat: add an `ariaLabel` prop to name the editor for screen readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,14 @@ mode: 'tree' | 'text' | 'table'
 
 Open the editor in `'tree'` mode (default), `'table'` mode, or `'text'` mode (formerly: `code` mode).
 
+#### ariaLabel
+
+```ts
+ariaLabel: string
+```
+
+The accessible name of the editor, applied to the contents of all three modes. Default value is `'JSON editor'`. Give each editor a name of its own when a page contains more than one, so screen reader users can tell them apart.
+
 #### mainMenuBar
 
 ```ts

--- a/src/lib/components/JSONEditor.svelte
+++ b/src/lib/components/JSONEditor.svelte
@@ -61,6 +61,7 @@
   const tabSizeDefault = 4
   const truncateTextSizeDefault = 1000
   const modeDefault = Mode.tree
+  const ariaLabelDefault = 'JSON editor'
   const mainMenuBarDefault = true
   const navigationBarDefault = true
   const statusBarDefault = true
@@ -100,6 +101,7 @@
   export let tabSize: number = tabSizeDefault
   export let truncateTextSize: number = truncateTextSizeDefault
   export let mode: Mode = modeDefault
+  export let ariaLabel: string = ariaLabelDefault
   export let mainMenuBar: boolean = mainMenuBarDefault
   export let navigationBar: boolean = navigationBarDefault
   export let statusBar: boolean = statusBarDefault
@@ -312,6 +314,9 @@
           break
         case 'mode':
           mode = props[name] ?? modeDefault
+          break
+        case 'ariaLabel':
+          ariaLabel = props[name] ?? ariaLabelDefault
           break
         case 'mainMenuBar':
           mainMenuBar = props[name] ?? mainMenuBarDefault
@@ -560,6 +565,7 @@
         {indentation}
         {tabSize}
         {truncateTextSize}
+        {ariaLabel}
         {statusBar}
         {askToFormat}
         {mainMenuBar}

--- a/src/lib/components/JSONEditor.test.ts
+++ b/src/lib/components/JSONEditor.test.ts
@@ -60,6 +60,27 @@ describe('JSONEditor', () => {
     expect(target).toMatchSnapshot()
   })
 
+  test('render a custom aria-label in all modes', () => {
+    const ariaLabel = 'Custom label'
+
+    const labelOf = (mode: Mode, selector: string): string | null | undefined => {
+      const target = document.createElement('div')
+
+      mount(JSONEditor, {
+        target,
+        props: { mode, content, ariaLabel }
+      })
+
+      flushSync() // wait until CodeMirror is rendered during onMount
+
+      return target.querySelector(selector)?.getAttribute('aria-label')
+    }
+
+    expect(labelOf(Mode.tree, '[role="tree"]')).toBe(ariaLabel)
+    expect(labelOf(Mode.table, '[role="table"]')).toBe(ariaLabel)
+    expect(labelOf(Mode.text, '.cm-content')).toBe(ariaLabel)
+  })
+
   test('render table mode', () => {
     const target = document.createElement('div')
 

--- a/src/lib/components/__snapshots__/JSONEditor.test.ts.snap
+++ b/src/lib/components/__snapshots__/JSONEditor.test.ts.snap
@@ -275,6 +275,7 @@ exports[`JSONEditor > render table mode 1`] = `
         class="jse-hidden-input-label svelte-1p86y3c"
       >
         <input
+          aria-hidden="true"
           class="jse-hidden-input svelte-1p86y3c"
           readonly=""
           tabindex="-1"
@@ -1771,6 +1772,7 @@ exports[`JSONEditor > render tree mode 1`] = `
         class="jse-hidden-input-label svelte-10mlrw4"
       >
         <input
+          aria-hidden="true"
           class="jse-hidden-input svelte-10mlrw4"
           readonly=""
           tabindex="-1"

--- a/src/lib/components/__snapshots__/JSONEditor.test.ts.snap
+++ b/src/lib/components/__snapshots__/JSONEditor.test.ts.snap
@@ -11,6 +11,7 @@ exports[`JSONEditor > render table mode 1`] = `
   >
     <!---->
     <div
+      aria-label="JSON editor"
       class="jse-table-mode svelte-1p86y3c"
       role="table"
     >
@@ -1157,6 +1158,7 @@ exports[`JSONEditor > render text mode 1`] = `
               </div>
             </div>
             <div
+              aria-label="JSON editor"
               aria-multiline="true"
               autocapitalize="off"
               autocorrect="off"
@@ -1356,6 +1358,7 @@ exports[`JSONEditor > render tree mode 1`] = `
   >
     <!---->
     <div
+      aria-label="JSON editor"
       class="jse-tree-mode svelte-10mlrw4"
       role="tree"
       tabindex="-1"

--- a/src/lib/components/modes/JSONEditorRoot.svelte
+++ b/src/lib/components/modes/JSONEditorRoot.svelte
@@ -49,6 +49,7 @@
   export let tabSize: number
   export let truncateTextSize: number
   export let externalMode: Mode
+  export let ariaLabel: string | undefined = undefined
   export let mainMenuBar: boolean
   export let navigationBar: boolean
   export let statusBar: boolean
@@ -341,6 +342,7 @@
     bind:this={refTextMode}
     externalContent={content}
     externalSelection={selection}
+    {ariaLabel}
     {history}
     {readOnly}
     {indentation}
@@ -370,6 +372,7 @@
     bind:this={refTableMode}
     externalContent={content}
     externalSelection={selection}
+    {ariaLabel}
     {history}
     {readOnly}
     {truncateTextSize}
@@ -402,6 +405,7 @@
     bind:this={refTreeMode}
     externalContent={content}
     externalSelection={selection}
+    {ariaLabel}
     {history}
     {readOnly}
     {indentation}

--- a/src/lib/components/modes/tablemode/TableMode.svelte
+++ b/src/lib/components/modes/tablemode/TableMode.svelte
@@ -167,6 +167,7 @@
   debug('isSSR:', isSSR)
 
   export let readOnly: boolean
+  export let ariaLabel: string | undefined = undefined
   export let externalContent: Content
   export let externalSelection: JSONEditorSelection | undefined
   export let history: History<HistoryItem>
@@ -1750,6 +1751,7 @@
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <div
   role="table"
+  aria-label={ariaLabel}
   class="jse-table-mode"
   class:no-main-menu={!mainMenuBar}
   on:mousedown={handleMouseDown}

--- a/src/lib/components/modes/tablemode/TableMode.svelte
+++ b/src/lib/components/modes/tablemode/TableMode.svelte
@@ -1776,10 +1776,13 @@
 
   {#if !isSSR}
     <label class="jse-hidden-input-label">
+      <!-- an off-screen input to capture paste and hold focus; it carries no
+           content of its own, so hide it from assistive technologies -->
       <input
         type="text"
         readonly={true}
         tabindex="-1"
+        aria-hidden="true"
         class="jse-hidden-input"
         bind:this={refHiddenInput}
         on:paste={handlePaste}

--- a/src/lib/components/modes/textmode/TextMode.svelte
+++ b/src/lib/components/modes/textmode/TextMode.svelte
@@ -135,6 +135,7 @@
   import { wrappedLineIndent } from 'codemirror-wrapped-line-indent/dist/index.js' // ensure loading ESM, otherwise the vitest test fail
 
   export let readOnly: boolean
+  export let ariaLabel: string | undefined = undefined
   export let mainMenuBar: boolean
   export let statusBar: boolean
   export let askToFormat: boolean
@@ -194,6 +195,7 @@
   const indentCompartment = new Compartment()
   const tabSizeCompartment = new Compartment()
   const themeCompartment = new Compartment()
+  const ariaLabelCompartment = new Compartment()
 
   let content: Content = externalContent
   let text = getText(content, indentation, parser) // text is just a cached version of content.text or parsed content.json
@@ -249,6 +251,7 @@
   $: updateIndentation(indentation)
   $: updateTabSize(tabSize)
   $: updateReadOnly(readOnly)
+  $: updateAriaLabel(ariaLabel)
 
   // force updating the text when escapeUnicodeCharacters changes
   let previousEscapeUnicodeCharacters = escapeUnicodeCharacters
@@ -927,7 +930,8 @@
         readOnlyCompartment.of(EditorState.readOnly.of(readOnly)),
         tabSizeCompartment.of(EditorState.tabSize.of(tabSize)),
         indentCompartment.of(createIndent(indentation)),
-        themeCompartment.of(EditorView.theme({}, { dark: hasDarkTheme() }))
+        themeCompartment.of(EditorView.theme({}, { dark: hasDarkTheme() })),
+        ariaLabelCompartment.of(createAriaLabel(ariaLabel))
       ]
     })
 
@@ -1154,6 +1158,20 @@
 
       codeMirrorView.dispatch({
         effects: tabSizeCompartment.reconfigure(EditorState.tabSize.of(tabSize))
+      })
+    }
+  }
+
+  function createAriaLabel(ariaLabel: string | undefined) {
+    return EditorView.contentAttributes.of(ariaLabel ? { 'aria-label': ariaLabel } : {})
+  }
+
+  function updateAriaLabel(ariaLabel: string | undefined) {
+    if (codeMirrorView) {
+      debug('updateAriaLabel', ariaLabel)
+
+      codeMirrorView.dispatch({
+        effects: [ariaLabelCompartment.reconfigure(createAriaLabel(ariaLabel))]
       })
     }
   }

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -1962,10 +1962,13 @@
 
   {#if !isSSR}
     <label class="jse-hidden-input-label">
+      <!-- an off-screen input to capture paste and hold focus; it carries no
+           content of its own, so hide it from assistive technologies -->
       <input
         type="text"
         readonly={true}
         tabindex="-1"
+        aria-hidden="true"
         class="jse-hidden-input"
         bind:this={refHiddenInput}
         on:paste={handlePaste}

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -184,6 +184,7 @@
   const jump = createJump()
 
   export let readOnly: boolean
+  export let ariaLabel: string | undefined = undefined
   export let externalContent: Content
   export let externalSelection: JSONEditorSelection | undefined
   export let history: History<HistoryItem>
@@ -1928,6 +1929,7 @@
 <div
   role="tree"
   tabindex="-1"
+  aria-label={ariaLabel}
   class="jse-tree-mode"
   class:no-main-menu={!mainMenuBar}
   on:keydown={handleKeyDown}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -596,6 +596,7 @@ export interface JSONEditorPropsOptional {
   content?: Content
   selection?: JSONEditorSelection
   readOnly?: boolean
+  ariaLabel?: string
   indentation?: number | string
   tabSize?: number
   truncateTextSize?: number


### PR DESCRIPTION
Picks up #451, and tries to answer the two questions that came up when #566 was closed.

## What is unnamed today

The contents of all three modes have no accessible name, so a screen reader announces the tree/table/text box without saying which editor it belongs to, and consumers cannot query the editor by label:

| mode | element carrying the contents | accessible name |
| --- | --- | --- |
| tree | `div.jse-tree-mode[role="tree"]` | — |
| table | `div.jse-table-mode[role="table"]` | — |
| text | CodeMirror `.cm-content` | — |

## Answering the questions from #566

> wouldn't it be enough to set an `aria-label` with a constant value? Is there need to make it customizable?

A constant is enough for the common case, so the prop *defaults* to `'JSON editor'` — every editor is named without the consumer doing anything. It is customizable because a constant cannot cover two cases: a page with more than one editor (a settings editor and a payload editor are then indistinguishable), and an application that is not in English, where a hard-coded English name is read out in the middle of a localized interface.

> I had the impression that there was need for an `aria-label` on the text editor, not on the JSONEditor as a whole

The label is applied per mode, to the element that actually carries the contents, rather than to the outer container as in #566 — an `aria-label` on the wrapper `div` has no effect, since the element has no role. Switching modes moves the label to the new mode's contents.

## The change

```svelte
<JSONEditor bind:content ariaLabel="Settings" />
```

- `JSONEditor.svelte` — the prop, its default, and a case in the `updateProps` switch so `vanilla-jsoneditor` can set it too
- `JSONEditorRoot.svelte` — forwards it to the three modes
- `TreeMode.svelte` / `TableMode.svelte` — `aria-label` on the `role="tree"` / `role="table"` container
- `TextMode.svelte` — `EditorView.contentAttributes`, wrapped in a `Compartment` and reconfigured on change, following the existing `readOnly`/`tabSize`/`theme` props so the label stays reactive
- `types.ts`, `README.md` — public type and docs

## Verification

`npm run check`, `npm run lint`, and `npm run test` all pass (510 tests). The three DOM snapshots in `JSONEditor.test.ts.snap` pick up the label, one per mode, and a new test asserts a custom value reaches the right element in each mode.

Checked in a browser against `examples/basic_usage_one_way_binding`: the label lands on `[role="tree"]`, `[role="table"]` and `.cm-content` as the mode changes, `getByLabel('JSON editor')` resolves, and changing the prop while text mode is open updates the live CodeMirror instance.

## Not included

Two things I left out to keep this reviewable, happy to add either here or in a follow-up:

- `input.jse-hidden-input` in tree and table mode has no accessible name, which axe reports as a violation (`label`). It is `tabindex="-1"` and only used for paste, so `aria-hidden="true"` would probably be the right fix.
- The nested editor inside `JSONEditorModal` gets no label; the modal has its own heading, so it did not seem necessary.