### PR TITLE
fix: do not scroll a scrollable ancestor when the editor gets focus

### DIFF
--- a/src/lib/components/modes/tablemode/TableMode.svelte
+++ b/src/lib/components/modes/tablemode/TableMode.svelte
@@ -708,8 +708,10 @@
     // with just .focus(), sometimes the input doesn't react on onpaste events
     // in Chrome when having a large document open and then doing cut/paste.
     // Calling both .focus() and .select() did solve this issue.
+    // the input is positioned outside of the editor, so revealing it would
+    // scroll a scrollable ancestor away from the contents the user clicked
     if (refHiddenInput) {
-      refHiddenInput.focus()
+      refHiddenInput.focus({ preventScroll: true })
       refHiddenInput.select()
     }
   }
@@ -725,7 +727,7 @@
         selection = removeEditModeFromSelection(selection)
 
         if (hasFocus && refHiddenInput) {
-          refHiddenInput.focus()
+          refHiddenInput.focus({ preventScroll: true })
           refHiddenInput.blur()
         }
 

--- a/src/lib/components/modes/treemode/TreeMode.svelte
+++ b/src/lib/components/modes/treemode/TreeMode.svelte
@@ -1844,8 +1844,10 @@
     // with just .focus(), sometimes the input doesn't react on onpaste events
     // in Chrome when having a large document open and then doing cut/paste.
     // Calling both .focus() and .select() did solve this issue.
+    // the input is positioned outside of the editor, so revealing it would
+    // scroll a scrollable ancestor away from the contents the user clicked
     if (refHiddenInput) {
-      refHiddenInput.focus()
+      refHiddenInput.focus({ preventScroll: true })
       refHiddenInput.select()
     }
   }
@@ -1861,7 +1863,7 @@
         selection = removeEditModeFromSelection(selection)
 
         if (hasFocus && refHiddenInput) {
-          refHiddenInput.focus()
+          refHiddenInput.focus({ preventScroll: true })
           refHiddenInput.blur()
         }
 


### PR DESCRIPTION
## The problem

When the editor sits inside a scrollable panel, clicking a node scrolls that panel to the top, away from the node the user just clicked.

Tree and table mode move focus to `input.jse-hidden-input`, which is deliberately kept out of sight ([`TreeMode.scss`](https://github.com/josdejong/svelte-jsoneditor/blob/develop/src/lib/components/modes/treemode/TreeMode.scss#L17-L26)):

```scss
.jse-hidden-input {
  position: fixed;
  top: -10px;
  left: -10px;
  width: 1px;
  height: 1px;
}
```

`position: fixed` normally resolves against the viewport, which puts the input outside every scroll container, and focusing it scrolls nothing. But an ancestor with `transform`, `filter`, `contain: layout`, `will-change: transform`, … becomes the containing block for fixed descendants. The input is then placed at *that ancestor's* top left corner — inside the scrollable panel — and the browser scrolls the panel to reveal it.

This is easy to hit in practice, because dialog/drawer components apply exactly those properties. The case I ran into is [bits-ui](https://github.com/huntabyte/bits-ui), which sets `contain: layout style` inline on its dialog content; the same happens with anything animating a panel via `transform`.

Note this is the same family of problem as #238, fixed then for Safari by giving the input a non-zero size.

## Reproduction

An ordinary `overflow: auto` container is *not* enough — the containing block is what matters:

```svelte
<div style="height: 200px; overflow: auto; contain: layout">
  <p style="height: 100px">spacer</p>
  <JSONEditor content={{ json }} />
</div>
```

Scroll to the bottom, then click a key. Measured on `develop`, with the container scrolled to 132:

| interaction | before | after |
| --- | --- | --- |
| click a key | 132 | **0** |
| double click a value | 132 | **0** |

## The change

`focus({ preventScroll: true })` at the four places that focus the hidden input (two per mode). Revealing that input is never wanted — it is positioned out of sight on purpose — while the editor's own scrolling is untouched.

With the fix, both interactions above leave the container at 132. Keyboard navigation still scrolls the editor's contents to follow the selection: arrowing down 25 rows moves `.jse-contents` from 0 to 368, identical to `develop`.

`npm run check`, `npm run lint` and `npm run test` (509 tests) all pass; no snapshot changed, since the DOM is unaffected.